### PR TITLE
Add Plan Issue page and sidebar navigation

### DIFF
--- a/src/pages/PlanIssue.jsx
+++ b/src/pages/PlanIssue.jsx
@@ -1,0 +1,34 @@
+export default function PlanIssue() {
+  return (
+    <div className="page">
+      <h1>Plan an issue</h1>
+      <p className="page-lead">
+        Turn an issue or rough request into a concrete implementation plan.
+      </p>
+
+      <section className="info-section">
+        <h2>Steps</h2>
+        <ol>
+          <li>Start from the problem, expected outcome, and acceptance criteria.</li>
+          <li>
+            If an issue exists, align to{' '}
+            <code>.github/ISSUE_TEMPLATE/feature-bug-chore.yml</code>.
+          </li>
+          <li>Search the codebase for the files most likely to be affected.</li>
+          <li>
+            Ask clarifying questions only when missing answers would change the
+            implementation.
+          </li>
+          <li>
+            Produce a phased plan with concrete files, real commands, and
+            verification steps.
+          </li>
+          <li>
+            If the work changes the operating model, include updates to{' '}
+            <code>docs/project_init.md</code>.
+          </li>
+        </ol>
+      </section>
+    </div>
+  )
+}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1,7 +1,9 @@
 import Home from './pages/Home.jsx'
 import Info from './pages/Info.jsx'
+import PlanIssue from './pages/PlanIssue.jsx'
 
 export const navRoutes = [
   { path: '/', label: 'Home', element: <Home /> },
   { path: '/info', label: 'Info', element: <Info /> },
+  { path: '/plan-issue', label: 'Plan Issue', element: <PlanIssue /> },
 ]


### PR DESCRIPTION
## Summary
- Add a new `Plan Issue` page at `/plan-issue` with six planning steps aligned to `.cursor/commands/plan-issue.md`.
- Register the page in `navRoutes` so it appears in the sidebar and is clickable.
- Reuse existing page classes to keep UI styling consistent with current pages.

## Plan reference
- `update_planning_page_copy_8fa36266.plan.md`

## Verification
- [x] `npm run build`

## Screenshots
- Not included.

## Follow-ups
- None.