### PR TITLE
feat: Create Issue page and create-pr guidance (#7)

### DIFF
--- a/.cursor/commands/create-pr.md
+++ b/.cursor/commands/create-pr.md
@@ -1,18 +1,36 @@
-# Create Pull Request
-
-Prepare a pull request for the current branch.
-
-## Steps
-
-1. Review local changes and summarize the user-visible or maintenance impact.
-2. Draft a concise commit message based on the actual change.
-3. Draft a PR title and body.
-4. Include:
-   - plan reference if one exists
-   - verification command(s) run and pass/fail status
-   - screenshots if UI changed, or an explicit screenshot waiver
-   - notable follow-up items if something was intentionally deferred
-   - **GitHub auto-close:** PR body must contain `Closes #<issue>` or `Fixes #<issue>` (merge into default branch closes the linked issue).
-5. When the tracked GitHub issue number is known: after opening or updating the PR, set the issue to **`status:in-review`** and remove any other `status:*` labels (exactly one `status:*` at a time). Do **not** set `status:done` at PR creation; use `status:done` only after merge if you still want that label on closed issues.
-6. If operating-model files changed, mention that `docs/project_init.md` was updated as part of the same change.
-7. If daily workflow guidance changed, mention whether `docs/operating_model_cheatsheet.md` was updated too.
+# Create Pull Request
+
+
+
+Prepare a pull request for the current branch.
+
+
+
+## Steps
+
+
+
+1. Review local changes and summarize the user-visible or maintenance impact.
+
+2. Draft a concise commit message based on the actual change.
+
+3. Draft a PR title and body.
+
+4. Include:
+
+   - plan reference if one exists
+
+   - verification command(s) run and pass/fail status
+
+   - screenshots if UI changed, or an explicit screenshot waiver
+
+   - notable follow-up items if something was intentionally deferred
+
+   - **GitHub auto-close (when this PR closes an issue):** PR body must contain `Closes #<issue>` or `Fixes #<issue>` (merge into default branch closes the linked issue). If there is **no** linked issue, do **not** invent one; omit auto-close lines and add a short note in the body that there is no issue (e.g. chore, docs, or work tracked outside GitHub).
+
+5. **Only when a tracked GitHub issue applies:** after opening or updating the PR, set the issue to **`status:in-review`** and remove any other `status:*` labels (exactly one `status:*` at a time). Do **not** set `status:done` at PR creation; use `status:done` only after merge if you still want that label on closed issues.
+
+6. If operating-model files changed, mention that `docs/project_init.md` was updated as part of the same change.
+
+7. If daily workflow guidance changed, mention whether `docs/operating_model_cheatsheet.md` was updated too.
+

--- a/src/pages/CreateIssue.jsx
+++ b/src/pages/CreateIssue.jsx
@@ -1,0 +1,81 @@
+export default function CreateIssue() {
+  return (
+    <div className="page">
+      <h1>Create GitHub Issue</h1>
+      <p className="page-lead">
+        Create a GitHub issue aligned to the repository template.
+      </p>
+
+      <section className="info-section">
+        <h2>Steps</h2>
+        <ol>
+          <li>
+            Confirm issue type: <code>Feature</code>, <code>Bug</code>, or{' '}
+            <code>Chore</code>.
+          </li>
+          <li>
+            Use{' '}
+            <code>.github/ISSUE_TEMPLATE/feature-bug-chore.yml</code> as the
+            required structure.
+          </li>
+          <li>
+            Draft the issue body with:
+            <ul>
+              <li>
+                <code>Problem / Goal</code>
+              </li>
+              <li>
+                <code>Expected Outcome</code>
+              </li>
+              <li>
+                <code>Acceptance Criteria (rough)</code> with checkboxes
+              </li>
+              <li>
+                <code>Context</code>
+              </li>
+            </ul>
+          </li>
+          <li>
+            Keep scope small and implementation-ready (avoid broad or mixed
+            goals).
+          </li>
+          <li>
+            For new issues, apply <code>status:needs-plan</code> only (remove any
+            other <code>status:*</code> labels). The canonical{' '}
+            <code>status:*</code> set is:
+            <ul>
+              <li>
+                <code>status:needs-plan</code> — new issue, not yet actively
+                planned
+              </li>
+              <li>
+                <code>status:in-progress</code> — planning or implementation in
+                progress
+              </li>
+              <li>
+                <code>status:in-review</code> — PR open, awaiting merge
+              </li>
+              <li>
+                <code>status:done</code> — after merge (optional; GitHub may
+                already have closed the issue via <code>Closes #</code> in the PR
+                body)
+              </li>
+            </ul>
+          </li>
+          <li>
+            Return the final issue title, labels, and body text for confirmation
+            before submit.
+          </li>
+        </ol>
+      </section>
+
+      <section className="info-section">
+        <h2>Notes</h2>
+        <ul>
+          <li>Prefer one issue per independently shippable change.</li>
+          <li>Use exactly one active <code>status:*</code> label at a time.</li>
+        </ul>
+      </section>
+    </div>
+  )
+}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1,9 +1,11 @@
 import Home from './pages/Home.jsx'
 import Info from './pages/Info.jsx'
 import PlanIssue from './pages/PlanIssue.jsx'
+import CreateIssue from './pages/CreateIssue.jsx'
 
 export const navRoutes = [
   { path: '/', label: 'Home', element: <Home /> },
   { path: '/info', label: 'Info', element: <Info /> },
   { path: '/plan-issue', label: 'Plan Issue', element: <PlanIssue /> },
+  { path: '/create-issue', label: 'Create Issue', element: <CreateIssue /> },
 ]


### PR DESCRIPTION
## Summary

Adds a **Create Issue** sidebar page at \/create-issue\ that mirrors \.cursor/commands/create-issue.md\ (Steps and Notes), using the same layout patterns as Plan Issue and Info.

Also updates \.cursor/commands/create-pr.md\: auto-close wording applies only when this PR closes a tracked issue; when there is no issue, omit \Closes #\ and note that in the PR body. Issue label step 5 applies only when a tracked GitHub issue exists.

## Plan

Follows the implementation plan for [issue #7](https://github.com/mysteriousflyingsquirrel/playground/issues/7) (in-app Create Issue guidance).

## Verification

- \
pm run build\ — **pass**

## UI

Screenshot not attached (static documentation-style page). Happy to add one if you want it in the PR.

## Deferred / follow-up

None.

## Docs

No changes to \docs/operating_model.md\, \docs/project_init.md\, or \docs/operating_model_cheatsheet.md\ in this PR.

Closes #7

Made with [Cursor](https://cursor.com)