### PR TITLE
docs: plan-issue status label timing after Plan Mode

### DIFF
--- a/.cursor/commands/plan-issue.md
+++ b/.cursor/commands/plan-issue.md
@@ -6,6 +6,8 @@ Turn an issue or rough request into a concrete implementation plan.
 
 1. Resolve issue source first: GitHub issue URL/number or pasted issue text.
 2. If the source is a GitHub issue, set it to **`status:in-progress`** and remove any other `status:*` labels so planning shows as active on the board.
+   - **Plan Mode** is often read-only: you may be unable to run GitHub CLI/API here—skip the label update until Agent mode.
+   - **Agent mode after Plan Mode:** Treat this as the **first action** once you continue from an approved plan—**before any code or file edits**—so the board moves to in-progress as soon as work starts, not after implementation.
 3. Start from the problem, expected outcome, and acceptance criteria.
 4. If an issue exists, align to `.github/ISSUE_TEMPLATE/feature-bug-chore.yml`.
 5. Search the codebase for the files most likely to be affected.

--- a/docs/operating_model_cheatsheet.md
+++ b/docs/operating_model_cheatsheet.md
@@ -78,6 +78,7 @@ Get a phased implementation plan with real files, risks, and verification steps 
 Do this:
 Tell the agent to use Plan Mode for non-trivial work.
 Resolve the issue source up front (GitHub issue URL/number vs pasted issue text).
+Plan Mode usually cannot set GitHub labels; after the plan is accepted, the **first** Agent-mode step is **`status:in-progress`** (drop other `status:*`) **before any edits**—see step 2 in `.cursor/commands/plan-issue.md`.
 
 Example prompt:
 
@@ -116,6 +117,7 @@ Execute the accepted scope without drifting into adjacent work.
 
 Do this:
 Tell the agent to implement the approved plan and keep changes scoped.
+If the source is a GitHub issue and labels are not already updated, apply **`status:in-progress`** (remove other `status:*`) **before** the first file change—see step 2 in `.cursor/commands/plan-issue.md`.
 
 Example prompt:
 
@@ -211,7 +213,7 @@ Update the relevant operating-model docs in the same change and summarize what c
 1. Create or refine the GitHub issue.
 2. Start a fresh Cursor chat.
 3. Use Plan Mode for non-trivial work.
-4. Approve the plan.
+4. Approve the plan. For GitHub-tracked work, set **`status:in-progress`** (and drop other **`status:*`**) **before** the first edit when you leave Plan Mode—see `.cursor/commands/plan-issue.md` step 2.
 5. Implement only the approved scope.
 6. Run real verification commands.
 7. Review locally.


### PR DESCRIPTION
## Summary

Clarifies that **status:in-progress** (step 2 in \/plan-issue\) should run in **Agent mode** as the **first action after an approved plan**, before any file edits—because **Plan Mode** is usually read-only for GitHub.

Updates \.cursor/commands/plan-issue.md\ and \docs/operating_model_cheatsheet.md\ (sections 3, 5, Standard Flow).

## Linked issue

**None** — workflow documentation only (no \Closes #\).

## Verification

- \
pm run build\ — **pass**

## Operating-model docs

- \docs/operating_model_cheatsheet.md\ — updated in this PR
- \docs/project_init.md\ — unchanged
- \docs/operating_model.md\ — unchanged

Made with [Cursor](https://cursor.com)