### PR TITLE
Issue #16: Add calendar page with range selection

### DIFF
--- a/.cursor/hooks/issue-status-labels.mjs
+++ b/.cursor/hooks/issue-status-labels.mjs
@@ -1,0 +1,132 @@
+/**
+ * GitHub issue status labels for builder-agent lifecycle (hooks + shared helpers).
+ * Fail-open: never throws; logs to stderr on recoverable gh failures.
+ */
+import { execSync, spawnSync } from 'node:child_process'
+
+export const STATUS = {
+  needsPlan: 'status:needs-plan',
+  inProgress: 'status:in-progress',
+  inReview: 'status:in-review',
+  done: 'status:done',
+}
+
+const ALL_STATUS = [STATUS.needsPlan, STATUS.inProgress, STATUS.inReview, STATUS.done]
+
+export function extractIssueNumber(...texts) {
+  for (const t of texts) {
+    const m = String(t || '').match(/#(\d+)/)
+    if (m) return parseInt(m[1], 10)
+  }
+  return null
+}
+
+export function getRepoSlug() {
+  if (process.env.GITHUB_REPOSITORY) return process.env.GITHUB_REPOSITORY.trim()
+  try {
+    const url = execSync('git remote get-url origin', {
+      encoding: 'utf8',
+      cwd: process.cwd(),
+    }).trim()
+    const m = url.match(/github\.com[:/]([^/]+\/[^/.]+)/)
+    if (!m) return null
+    return m[1].replace(/\.git$/i, '')
+  } catch {
+    return null
+  }
+}
+
+function log(...args) {
+  console.error('[issue-status-labels]', ...args)
+}
+
+function gh(args) {
+  return spawnSync('gh', args, {
+    encoding: 'utf8',
+    shell: false,
+  })
+}
+
+function ghIssueEdit(repo, issue, extraArgs) {
+  const r = gh(['issue', 'edit', String(issue), '--repo', repo, ...extraArgs])
+  if (r.status !== 0 && r.stderr) {
+    log('gh stderr:', r.stderr.trim())
+  }
+  return r
+}
+
+/** Remove status labels that might be present; ignore missing-label errors. */
+function removeStatusLabels(repo, issue, except) {
+  for (const label of ALL_STATUS) {
+    if (label === except) continue
+    gh(['issue', 'edit', String(issue), '--repo', repo, '--remove-label', label])
+  }
+}
+
+export function isBuilderSubagent(payload) {
+  const typ = String(payload.subagent_type || '')
+  if (typ === 'builder-agent' || typ === 'builder_agent') return true
+  const task = String(payload.task || '')
+  if (/\bbuilder-agent\b/i.test(task)) return true
+  const desc = String(payload.description || '')
+  if (/builder/i.test(desc) && /approved plan/i.test(desc)) return true
+  return false
+}
+
+export function validateBuilderIssueContext(payload) {
+  if (!isBuilderSubagent(payload)) return { ok: true, issue: null, repo: null }
+  const issue = extractIssueNumber(payload.task, payload.description, payload.summary)
+  if (!issue) return { ok: false, reason: 'missing_issue' }
+  const repo = getRepoSlug()
+  if (!repo) return { ok: false, reason: 'missing_repo', issue }
+  return { ok: true, issue, repo }
+}
+
+/**
+ * subagentStart: transition to status:in-progress when builder starts.
+ */
+export function applyBuilderStartLabel(payload) {
+  if (!isBuilderSubagent(payload)) return { ok: true, skipped: true }
+  const issue = extractIssueNumber(payload.task, payload.description, payload.summary)
+  if (!issue) {
+    log('skip in-progress: no #issue in task')
+    return { ok: false, reason: 'missing_issue' }
+  }
+  const repo = getRepoSlug()
+  if (!repo) {
+    log('skip in-progress: could not resolve repo from origin')
+    return { ok: false, reason: 'missing_repo', issue }
+  }
+  removeStatusLabels(repo, issue, STATUS.inProgress)
+  const r = ghIssueEdit(repo, issue, ['--add-label', STATUS.inProgress])
+  if (r.status !== 0) {
+    log('gh issue edit in-progress failed', r.status)
+    return { ok: false, reason: 'gh_label_update_failed', issue, repo }
+  }
+  return { ok: true, issue, repo }
+}
+
+/**
+ * subagentStop: transition to status:in-review when builder completes successfully.
+ */
+export function applyBuilderStopLabel(payload) {
+  if (!isBuilderSubagent(payload)) return { ok: true, skipped: true }
+  if (payload.status !== 'completed') return { ok: true, skipped: true }
+  const issue = extractIssueNumber(payload.task, payload.summary)
+  if (!issue) {
+    log('skip in-review: no #issue in task/summary')
+    return { ok: false, reason: 'missing_issue' }
+  }
+  const repo = getRepoSlug()
+  if (!repo) {
+    log('skip in-review: could not resolve repo from origin')
+    return { ok: false, reason: 'missing_repo', issue }
+  }
+  removeStatusLabels(repo, issue, STATUS.inReview)
+  const r = ghIssueEdit(repo, issue, ['--add-label', STATUS.inReview])
+  if (r.status !== 0) {
+    log('gh issue edit in-review failed', r.status)
+    return { ok: false, reason: 'gh_label_update_failed', issue, repo }
+  }
+  return { ok: true, issue, repo }
+}

--- a/.cursor/hooks/pre-implementation-check.mjs
+++ b/.cursor/hooks/pre-implementation-check.mjs
@@ -1,7 +1,6 @@
 /**
  * Maps to conceptual hook: pre-implementation-check (beforeSubmitPrompt).
- * Default: fail-open. Set CURSOR_STRICT_PLAN_GATE=1 to block prompts that look
- * like implementation starts without an issue ref (#nnn) or plan marker.
+ * Hard gate: implementation must be delegated to builder-agent.
  */
 import fs from 'node:fs'
 
@@ -20,21 +19,22 @@ try {
 }
 
 const prompt = String(payload.prompt || '')
-const strict = process.env.CURSOR_STRICT_PLAN_GATE === '1'
-
 const looksImplement =
-  /\b(implement|build\s+out|add\s+(a\s+)?feature|write\s+code|start\s+(coding|implementation))\b/i.test(
+  /\b(implement|implementation|build(\s+out)?|write\s+code|start\s+(coding|implementation)|code\s+it|create|add|fix|change|modify|update|ship|deliver)\b/i.test(
     prompt
-  )
+  ) || /\b(do\s+it|go\s+ahead)\b/i.test(prompt)
 
-const hasIssue = /#\d+/.test(prompt)
-const hasPlan = /\bPLAN:\b|\.cursor\/plans\//i.test(prompt)
+const referencesWorkflowContext = /#\d+|\.cursor\/plans\/|\/plan-from-issue|approved\s+plan/i.test(
+  prompt
+)
 
-if (strict && looksImplement && !hasIssue && !hasPlan) {
+const mentionsBuilderAgent = /\bbuilder-agent\b/i.test(prompt)
+
+if ((looksImplement || referencesWorkflowContext) && !mentionsBuilderAgent) {
   out({
     continue: false,
     user_message:
-      'Implementation-style prompt blocked until you add an issue reference (#123) or an explicit plan marker (e.g. PLAN: or .cursor/plans/...). Unset strict mode by removing CURSOR_STRICT_PLAN_GATE=1.',
+      'Implementation is blocked unless it is explicitly delegated to builder-agent. Re-run using builder-agent with the approved plan and issue number (for example: "delegate builder-agent for Issue #16").',
   })
   process.exit(0)
 }

--- a/.cursor/hooks/shell-policy.mjs
+++ b/.cursor/hooks/shell-policy.mjs
@@ -3,6 +3,7 @@
  * beforeShellExecution — return permission JSON.
  */
 import fs from 'node:fs'
+import { execSync } from 'node:child_process'
 
 const stdin = fs.readFileSync(0, 'utf8')
 let payload = {}
@@ -59,16 +60,47 @@ if (/\bgit\s+push\b/i.test(command)) {
     )
     process.exit(0)
   }
+
+  // Also block bare push when currently on protected branch.
+  const hasExplicitRefSpec =
+    /:/.test(command) ||
+    /\sorigin\s+\S+/.test(command) ||
+    /\supstream\s+\S+/.test(command)
+  if (!hasExplicitRefSpec) {
+    try {
+      const currentBranch = execSync('git rev-parse --abbrev-ref HEAD', {
+        encoding: 'utf8',
+        cwd: process.cwd(),
+      }).trim()
+      if (currentBranch === 'main' || currentBranch === 'dev') {
+        printDeny(
+          `Push from ${currentBranch} blocked by project hook.`,
+          `Do not push while checked out on ${currentBranch}. Switch to a feature branch and push that branch only; PRs must target dev.`
+        )
+        process.exit(0)
+      }
+    } catch {
+      // Fail open if current branch cannot be resolved.
+    }
+  }
 }
 
 // Enforce PR base dev for gh pr create
 if (/\bgh(\.exe)?\s+pr\s+create\b/i.test(command)) {
   const hasBaseDev = /--base(\s+|=)dev\b/i.test(command)
   const hasBaseMain = /--base(\s+|=)main\b/i.test(command)
+  const hasIssueCloseRef = /\b(Closes|Fixes)\s+#\d+\b/i.test(command)
   if (hasBaseMain || !hasBaseDev) {
     printDeny(
       'PR must target dev.',
       'Re-run with an explicit dev base, e.g. gh pr create --base dev (and do not use --base main). Agents must not open PRs to main.'
+    )
+    process.exit(0)
+  }
+  if (!hasIssueCloseRef) {
+    printDeny(
+      'PR body must link issue closure.',
+      'Re-run gh pr create and include "Closes #<n>" or "Fixes #<n>" in the PR body so label automation can transition to status:done after merge to dev.'
     )
     process.exit(0)
   }

--- a/.cursor/hooks/subagent-start-review-gate.mjs
+++ b/.cursor/hooks/subagent-start-review-gate.mjs
@@ -1,7 +1,14 @@
 /**
- * Conceptual: review-gate — v1 allows all subagents; optional stderr log.
+ * review-gate — v1 allows all subagents; optional stderr log.
+ * When builder-agent starts, set GitHub issue label status:in-progress (see issue-status-labels.mjs).
  */
 import fs from 'node:fs'
+import {
+  applyBuilderStartLabel,
+  extractIssueNumber,
+  isBuilderSubagent,
+  validateBuilderIssueContext,
+} from './issue-status-labels.mjs'
 
 const stdin = fs.readFileSync(0, 'utf8')
 let payload = {}
@@ -15,6 +22,50 @@ try {
 const type = payload.subagent_type || ''
 const task = String(payload.task || '').slice(0, 200)
 console.error(`[subagentStart] type=${type} task=${task}`)
+
+if (isBuilderSubagent(payload)) {
+  const issue = extractIssueNumber(payload.task, payload.description)
+  if (!issue) {
+    process.stdout.write(
+      JSON.stringify({
+        permission: 'deny',
+        user_message:
+          'builder-agent start blocked: include an issue reference like #16 in the delegated task so GitHub status labels can be updated.',
+        agent_message:
+          'Include #<n> in the builder-agent task text (for example "Build Issue #16") so hooks can set status:in-progress and status:in-review.',
+      })
+    )
+    process.exit(0)
+  }
+
+  const validation = validateBuilderIssueContext(payload)
+  if (!validation.ok) {
+    process.stdout.write(
+      JSON.stringify({
+        permission: 'deny',
+        user_message:
+          'builder-agent start blocked: cannot verify GitHub issue context for label automation. Ensure gh auth is active, origin points to GitHub, and issue # exists in this repo.',
+        agent_message:
+          'Fix GitHub context before delegation (gh auth status, correct origin repo, valid issue number), then retry builder-agent.',
+      })
+    )
+    process.exit(0)
+  }
+}
+
+const startResult = applyBuilderStartLabel(payload)
+if (isBuilderSubagent(payload) && !startResult?.ok) {
+  process.stdout.write(
+    JSON.stringify({
+      permission: 'deny',
+      user_message:
+        'builder-agent start blocked: failed to set issue status:in-progress. Resolve GitHub permissions/auth and retry.',
+      agent_message:
+        'Issue label transition failed at builder start; fix gh access/permissions, then rerun builder-agent so status automation stays accurate.',
+    })
+  )
+  process.exit(0)
+}
 
 process.stdout.write(JSON.stringify({ permission: 'allow' }))
 process.exit(0)

--- a/.cursor/hooks/subagent-stop-review-loop.mjs
+++ b/.cursor/hooks/subagent-stop-review-loop.mjs
@@ -1,7 +1,9 @@
 /**
- * Conceptual: review-fix-loop — if subagent summary contains [[BLOCKING]], nudge fix-from-review + builder + re-review.
+ * review-fix-loop — if subagent summary contains [[BLOCKING]], nudge fix-from-review + builder + re-review.
+ * When builder-agent completes successfully, set GitHub issue label status:in-review (see issue-status-labels.mjs).
  */
 import fs from 'node:fs'
+import { applyBuilderStopLabel } from './issue-status-labels.mjs'
 
 const stdin = fs.readFileSync(0, 'utf8')
 let payload = {}
@@ -12,16 +14,25 @@ try {
   process.exit(0)
 }
 
+const stopResult = applyBuilderStopLabel(payload)
+
 const summary = String(payload.summary || '')
-if (!summary.includes('[[BLOCKING]]')) {
+if (!summary.includes('[[BLOCKING]]') && (stopResult?.ok || stopResult?.skipped)) {
   process.stdout.write('{}')
   process.exit(0)
 }
 
-process.stdout.write(
-  JSON.stringify({
-    followup_message:
-      'Subagent reported [[BLOCKING]]. Run /fix-from-review, delegate builder-agent on the same feature branch, then re-run code-review-agent and ui-review-agent (or UI N/A per ui-review-agent instructions).',
-  })
-)
+const messages = []
+if (summary.includes('[[BLOCKING]]')) {
+  messages.push(
+    'Subagent reported [[BLOCKING]]. Run /fix-from-review, delegate builder-agent on the same feature branch, then re-run code-review-agent and ui-review-agent (or UI N/A per ui-review-agent instructions).'
+  )
+}
+if (!(stopResult?.ok || stopResult?.skipped)) {
+  messages.push(
+    'builder-agent completed but issue label transition to status:in-review failed. Fix gh auth/permissions and update labels manually before proceeding.'
+  )
+}
+
+process.stdout.write(JSON.stringify({ followup_message: messages.join('\n\n') }))
 process.exit(0)

--- a/.cursor/rules/git-workflow.mdc
+++ b/.cursor/rules/git-workflow.mdc
@@ -12,6 +12,20 @@ alwaysApply: false
 - **Humans** merge approved PRs into **`dev`** and later promote **`dev` → `main`**.
 - **Never** target **`main`** with agent-created PRs, direct pushes to `main`, or agent-driven merges into `main`.
 
+## Builder-only implementation (hard rule)
+
+- After plan acceptance, **all implementation must be delegated to `builder-agent`**.
+- The primary agent must not directly implement feature code in Agent mode or Plan mode.
+- Implementation requests must explicitly mention **`builder-agent`** in the prompt/task.
+- Builder delegation tasks must include an issue reference (**`#<n>`**) so local hooks can update GitHub status labels.
+
+## GitHub label workflow (required)
+
+- On `builder-agent` start, hooks set issue label **`status:in-progress`**.
+- On successful `builder-agent` completion (PR ready), hooks set **`status:in-review`**.
+- PR body must include **`Closes #<n>`** or **`Fixes #<n>`** so merge automation can set **`status:done`** on merge to `dev`.
+- If `#<n>` is missing from builder delegation, hook enforcement blocks builder startup.
+
 ## Promotion to main
 
 - **`dev` → `main`** is a **human-controlled** release step, after checks on `dev` and the [release-readiness](@.cursor/skills/release-readiness/SKILL.md) checklist.

--- a/.github/scripts/issue-status-on-pr-merge.mjs
+++ b/.github/scripts/issue-status-on-pr-merge.mjs
@@ -1,0 +1,51 @@
+/**
+ * On PR merge to dev: add status:done, drop prior status labels, close linked issues.
+ * Issue numbers: PR body (Closes/Fixes/Resolves #n) and head branch issue-<n> per builder naming.
+ */
+import { spawnSync } from 'node:child_process'
+
+const body = String(process.env.PR_BODY || '')
+const headRef = String(process.env.HEAD_REF || '')
+
+const fromBody = new Set()
+const re =
+  /(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s*#(\d+)/gi
+let m
+while ((m = re.exec(body)) !== null) {
+  fromBody.add(parseInt(m[1], 10))
+}
+
+const fromBranch = new Set()
+const bm = headRef.match(/(?:^|[/-])issue-(\d+)/i)
+if (bm) fromBranch.add(parseInt(bm[1], 10))
+
+const nums = [...new Set([...fromBody, ...fromBranch])]
+if (nums.length === 0) {
+  console.log('No issue numbers from PR body or head ref; nothing to do.')
+  process.exit(0)
+}
+
+const STATUS = {
+  needsPlan: 'status:needs-plan',
+  done: 'status:done',
+  inProgress: 'status:in-progress',
+  inReview: 'status:in-review',
+}
+
+function gh(args) {
+  const r = spawnSync('gh', args, { encoding: 'utf8', shell: false })
+  if (r.status !== 0) {
+    console.error('gh failed:', args.join(' '), r.stderr || r.stdout)
+  }
+  return r.status === 0
+}
+
+for (const n of nums) {
+  gh(['issue', 'edit', String(n), '--add-label', STATUS.done])
+  gh(['issue', 'edit', String(n), '--remove-label', STATUS.needsPlan])
+  gh(['issue', 'edit', String(n), '--remove-label', STATUS.inProgress])
+  gh(['issue', 'edit', String(n), '--remove-label', STATUS.inReview])
+  gh(['issue', 'close', String(n)])
+}
+
+console.log('Updated issues:', nums.join(', '))

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Subagents, cloud agents, and any automated actor in this workflow must:
 ## Rules and automation
 
 - **Rules:** [.cursor/rules/git-workflow.mdc](.cursor/rules/git-workflow.mdc), [.cursor/rules/architecture.mdc](.cursor/rules/architecture.mdc), [.cursor/rules/ui-system.mdc](.cursor/rules/ui-system.mdc) when applicable.
-- **Hooks:** [.cursor/hooks.json](.cursor/hooks.json) — optional strict plan gate via `CURSOR_STRICT_PLAN_GATE=1`, post-edit **`npm run build`** when `src/` changed, shell policy for PR base and risky `git push`, subagent follow-up on **`[[BLOCKING]]`**. See the architecture doc for the wiring table.
+- **Hooks:** [.cursor/hooks.json](.cursor/hooks.json) — hard pre-implementation gate requiring explicit `builder-agent` delegation for implementation/workflow-execution prompts, post-edit **`npm run build`** when `src/` changed, shell policy for PR base and risky `git push` (including bare pushes from `dev`/`main`), subagent follow-up on **`[[BLOCKING]]`**, and builder start enforcement requiring `#<n>` for label automation. See the architecture doc for the wiring table.
 
 ## Verification
 

--- a/docs/cursor-operating-model-architecture.md
+++ b/docs/cursor-operating-model-architecture.md
@@ -13,7 +13,7 @@ This document maps the project’s **rules**, **skills**, **subagents**, and **h
 
 **Cloud agent** and **subagents** follow the same rules as above (see [Cloud agent](https://cursor.com/docs/cloud-agent) in [cursor_sources.md](cursor_sources.md)).
 
-Hooks enforce part of this via `beforeShellExecution` (see hook wiring below). A bare **`git push`** while checked out on **`dev`** cannot be reliably detected from the command string alone; **AGENTS.md** and **builder-agent** instructions rely on policy compliance for that case.
+Hooks enforce part of this via `beforeShellExecution` (see hook wiring below). The shell policy now blocks explicit pushes to protected branches and also blocks bare `git push` when currently checked out on `dev` or `main`.
 
 ---
 
@@ -84,11 +84,13 @@ Official hook reference: [Hooks](https://cursor.com/docs/hooks) (also listed in 
 
 | Conceptual hook | Cursor `hooks.json` key | Script | Behavior (v1) |
 |-----------------|-------------------------|--------|----------------|
-| pre-implementation-check | `beforeSubmitPrompt` | [pre-implementation-check.mjs](../.cursor/hooks/pre-implementation-check.mjs) | Fail-open unless `CURSOR_STRICT_PLAN_GATE=1`; then block “implementation-like” prompts without `#issue` or plan marker. |
+| pre-implementation-check | `beforeSubmitPrompt` | [pre-implementation-check.mjs](../.cursor/hooks/pre-implementation-check.mjs) | Hard gate: block implementation/workflow-execution prompts (including issue/plan-context prompts) unless they explicitly delegate to **`builder-agent`**. |
 | post-implementation-check | `afterFileEdit` + `stop` | [after-file-edit-dirty.mjs](../.cursor/hooks/after-file-edit-dirty.mjs), [stop-post-build.mjs](../.cursor/hooks/stop-post-build.mjs) | After `Write` under `src/`, create `.cursor/hooks/.dirty` (gitignored). On agent `stop` + `completed`, run `npm run build` if dirty was set. |
-| pr-open-trigger (+ branch policy) | `beforeShellExecution` | [shell-policy.mjs](../.cursor/hooks/shell-policy.mjs) | Deny `gh pr create` without `--base dev` or with `--base main`; deny `git push` targeting **`main`** or **`dev`** as destination; on valid `gh pr create`, remind to run **code-review-agent** then **ui-review-agent** (UI N/A rule applies). |
-| review-gate | `subagentStart` | [subagent-start-review-gate.mjs](../.cursor/hooks/subagent-start-review-gate.mjs) | v1: allow all; logs type/task to stderr. |
-| review-fix-loop | `subagentStop` | [subagent-stop-review-loop.mjs](../.cursor/hooks/subagent-stop-review-loop.mjs) | If `summary` contains `[[BLOCKING]]`, emit `followup_message` for `/fix-from-review` and **builder-agent**, then re-run review subagents. |
+| pr-open-trigger (+ branch policy) | `beforeShellExecution` | [shell-policy.mjs](../.cursor/hooks/shell-policy.mjs) | Deny `gh pr create` without `--base dev`, with `--base main`, or without `Closes #<n>`/`Fixes #<n>` in body text; deny `git push` targeting **`main`**/**`dev`** and deny bare `git push` while checked out on **`main`**/**`dev`**; on valid `gh pr create`, remind to run **code-review-agent** then **ui-review-agent** (UI N/A rule applies). |
+| review-gate + builder issue labels | `subagentStart` | [subagent-start-review-gate.mjs](../.cursor/hooks/subagent-start-review-gate.mjs) → [issue-status-labels.mjs](../.cursor/hooks/issue-status-labels.mjs) | Allow subagents by default. For **builder-agent**, enforce `#<n>` in delegated task/description and validate GitHub context; deny start if missing/invalid. On valid start, set GitHub issue **`status:in-progress`** via local **`gh`**; deny if label update fails. |
+| review-fix-loop + builder issue labels | `subagentStop` | [subagent-stop-review-loop.mjs](../.cursor/hooks/subagent-stop-review-loop.mjs) → [issue-status-labels.mjs](../.cursor/hooks/issue-status-labels.mjs) | When **builder-agent** completes successfully, set **`status:in-review`**. If that label update fails, emit a mandatory follow-up to fix labels before proceeding. If `summary` contains `[[BLOCKING]]`, also emit fix-loop follow-up for `/fix-from-review` and **builder-agent**. |
+
+There is only one `subagentStart` and one `subagentStop` entry in [`hooks.json`](../.cursor/hooks.json) so each hook prints a single JSON payload to stdout. Builder label logic lives in [issue-status-labels.mjs](../.cursor/hooks/issue-status-labels.mjs) and is invoked from those scripts (not as a second `hooks.json` entry) to avoid invalid combined output.
 
 **`stop` / `subagentStop` follow-ups** respect per-hook `loop_limit` (see `hooks.json`; default Cursor cap applies).
 
@@ -97,6 +99,7 @@ Official hook reference: [Hooks](https://cursor.com/docs/hooks) (also listed in 
 ## Out of scope for Cursor hooks
 
 - **GitHub “PR opened” webhooks** and org-level automation are not replaced by project hooks; use **GitHub Actions** or integrations for server-side rules.
+- **PR merged into `dev`** — setting issue **`status:done`**, removing prior status labels, and **closing** linked issues are implemented in [.github/workflows/issue-status-on-pr-merge.yml](../.github/workflows/issue-status-on-pr-merge.yml) (not in Cursor hooks).
 - **Team-wide enforcement** may use Cursor **Team Rules** / enterprise features ([Rules](https://cursor.com/docs/rules)) in addition to this repo.
 
 ---

--- a/src/index.css
+++ b/src/index.css
@@ -218,3 +218,136 @@ body {
   visibility: hidden;
   min-height: 2.75rem;
 }
+
+/* Calendar (Issue #16) */
+.calendar-field-label {
+  display: block;
+  margin: 0 0 0.35rem;
+  font-size: 0.875rem;
+  color: var(--muted);
+}
+
+.calendar-range-field {
+  width: 100%;
+  max-width: 22rem;
+  margin: 0 0 1rem;
+  padding: 0.6rem 0.75rem;
+  font: inherit;
+  color: var(--text);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.calendar-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0 0 1rem;
+}
+
+.calendar-nav-label {
+  color: var(--text);
+  font-weight: 500;
+}
+
+.calendar-nav-btn {
+  margin: 0;
+  padding: 0.45rem 0.7rem;
+  font: inherit;
+  color: var(--text);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
+}
+
+.calendar-nav-btn:hover {
+  background: rgba(110, 181, 255, 0.12);
+  border-color: var(--accent-dim);
+}
+
+.calendar-nav-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.calendar-months {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.calendar-month {
+  min-width: 18rem;
+  padding: 0.85rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.calendar-month-title {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.35rem;
+}
+
+.calendar-grid--weekdays {
+  margin-bottom: 0.35rem;
+}
+
+.calendar-weekday {
+  display: flex;
+  justify-content: center;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.calendar-day {
+  margin: 0;
+  min-height: 2.25rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font: inherit;
+  color: var(--text);
+  background: var(--bg);
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
+}
+
+.calendar-day:hover {
+  background: rgba(110, 181, 255, 0.1);
+  border-color: var(--accent-dim);
+}
+
+.calendar-day:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.calendar-day--in-range {
+  background: rgba(110, 181, 255, 0.15);
+}
+
+.calendar-day--edge {
+  color: var(--text);
+  background: rgba(110, 181, 255, 0.35);
+  border-color: var(--accent-dim);
+  font-weight: 600;
+}
+
+.calendar-day--today {
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+
+.calendar-day--disabled {
+  visibility: hidden;
+  pointer-events: none;
+}

--- a/src/pages/Calendar.jsx
+++ b/src/pages/Calendar.jsx
@@ -1,0 +1,239 @@
+import { useMemo, useState } from 'react'
+
+const WEEKDAY_LABELS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']
+const MONTH_LABELS = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+]
+
+function dateAtMidday(year, month, day) {
+  return new Date(year, month, day, 12, 0, 0, 0)
+}
+
+function addMonths(baseYear, baseMonth, offset) {
+  const next = new Date(baseYear, baseMonth + offset, 1)
+  return { year: next.getFullYear(), month: next.getMonth() }
+}
+
+function getMonthDays(year, month) {
+  const firstWeekday = dateAtMidday(year, month, 1).getDay()
+  const dayCount = new Date(year, month + 1, 0).getDate()
+  const cells = []
+
+  for (let i = 0; i < firstWeekday; i += 1) {
+    cells.push(null)
+  }
+
+  for (let day = 1; day <= dayCount; day += 1) {
+    cells.push(dateAtMidday(year, month, day))
+  }
+
+  while (cells.length % 7 !== 0) {
+    cells.push(null)
+  }
+
+  return cells
+}
+
+function isSameDay(a, b) {
+  if (!a || !b) return false
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  )
+}
+
+function toDateInputValue(date) {
+  const year = String(date.getFullYear())
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function normalizeRange(start, end) {
+  if (!start || !end) return null
+  return start <= end ? { start, end } : { start: end, end: start }
+}
+
+function MonthGrid({
+  year,
+  month,
+  rangeStart,
+  rangeEnd,
+  hoverDate,
+  onPickDate,
+  onHoverDate,
+  onLeaveGrid,
+}) {
+  const monthTitle = `${MONTH_LABELS[month]} ${year}`
+  const today = dateAtMidday(
+    new Date().getFullYear(),
+    new Date().getMonth(),
+    new Date().getDate(),
+  )
+  const cells = useMemo(() => getMonthDays(year, month), [year, month])
+  const previewRange = rangeEnd ? null : normalizeRange(rangeStart, hoverDate)
+  const selectedRange = normalizeRange(rangeStart, rangeEnd)
+
+  return (
+    <section className="calendar-month" aria-label={monthTitle} onMouseLeave={onLeaveGrid}>
+      <h2 className="calendar-month-title">{monthTitle}</h2>
+      <div className="calendar-grid calendar-grid--weekdays" aria-hidden="true">
+        {WEEKDAY_LABELS.map((label) => (
+          <span key={label} className="calendar-weekday">
+            {label}
+          </span>
+        ))}
+      </div>
+      <div className="calendar-grid">
+        {cells.map((date, index) => {
+          if (!date) {
+            return <span key={`empty-${month}-${index}`} className="calendar-day calendar-day--disabled" />
+          }
+
+          const activeRange = selectedRange ?? previewRange
+          const inRange =
+            !!activeRange && date >= activeRange.start && date <= activeRange.end
+          const isEdge =
+            (rangeStart && isSameDay(date, rangeStart)) || (rangeEnd && isSameDay(date, rangeEnd))
+          const isToday = isSameDay(date, today)
+          const classNames = [
+            'calendar-day',
+            inRange ? 'calendar-day--in-range' : '',
+            isEdge ? 'calendar-day--edge' : '',
+            isToday ? 'calendar-day--today' : '',
+          ]
+            .filter(Boolean)
+            .join(' ')
+
+          return (
+            <button
+              key={toDateInputValue(date)}
+              type="button"
+              className={classNames}
+              onClick={() => onPickDate(date)}
+              onMouseEnter={() => onHoverDate(date)}
+              aria-pressed={isEdge}
+            >
+              {date.getDate()}
+            </button>
+          )
+        })}
+      </div>
+    </section>
+  )
+}
+
+export default function Calendar() {
+  const now = new Date()
+  const [baseYear, setBaseYear] = useState(now.getFullYear())
+  const [baseMonth, setBaseMonth] = useState(now.getMonth())
+  const [rangeStart, setRangeStart] = useState(null)
+  const [rangeEnd, setRangeEnd] = useState(null)
+  const [hoverDate, setHoverDate] = useState(null)
+
+  const leftMonth = { year: baseYear, month: baseMonth }
+  const rightMonth = addMonths(baseYear, baseMonth, 1)
+
+  function shiftMonths(offset) {
+    const shifted = addMonths(baseYear, baseMonth, offset)
+    setBaseYear(shifted.year)
+    setBaseMonth(shifted.month)
+  }
+
+  function handlePickDate(date) {
+    if (!rangeStart || (rangeStart && rangeEnd)) {
+      setRangeStart(date)
+      setRangeEnd(null)
+      setHoverDate(null)
+      return
+    }
+
+    if (date <= rangeStart) {
+      setRangeStart(date)
+      setRangeEnd(rangeStart)
+      setHoverDate(null)
+      return
+    }
+
+    setRangeEnd(date)
+    setHoverDate(null)
+  }
+
+  const rangeText = useMemo(() => {
+    if (!rangeStart) return ''
+    if (!rangeEnd) return toDateInputValue(rangeStart)
+    const range = normalizeRange(rangeStart, rangeEnd)
+    return `${toDateInputValue(range.start)} - ${toDateInputValue(range.end)}`
+  }, [rangeStart, rangeEnd])
+
+  const monthLabel = (year, month) => `${MONTH_LABELS[month]} ${year}`
+
+  return (
+    <div className="page">
+      <h1>Calendar</h1>
+      <p className="page-lead">
+        Select a <strong>date range</strong> by clicking a start and end date.
+      </p>
+
+      <label className="calendar-field-label" htmlFor="calendar-range">
+        Selected range
+      </label>
+      <input
+        id="calendar-range"
+        className="calendar-range-field"
+        type="text"
+        readOnly
+        placeholder="No dates selected"
+        value={rangeText}
+      />
+
+      <div className="calendar-nav">
+        <button type="button" className="calendar-nav-btn" onClick={() => shiftMonths(-1)}>
+          Prev
+        </button>
+        <div className="calendar-nav-label">
+          {monthLabel(leftMonth.year, leftMonth.month)} /{' '}
+          {monthLabel(rightMonth.year, rightMonth.month)}
+        </div>
+        <button type="button" className="calendar-nav-btn" onClick={() => shiftMonths(1)}>
+          Next
+        </button>
+      </div>
+
+      <div className="calendar-months">
+        <MonthGrid
+          year={leftMonth.year}
+          month={leftMonth.month}
+          rangeStart={rangeStart}
+          rangeEnd={rangeEnd}
+          hoverDate={hoverDate}
+          onPickDate={handlePickDate}
+          onHoverDate={setHoverDate}
+          onLeaveGrid={() => setHoverDate(null)}
+        />
+        <MonthGrid
+          year={rightMonth.year}
+          month={rightMonth.month}
+          rangeStart={rangeStart}
+          rangeEnd={rangeEnd}
+          hoverDate={hoverDate}
+          onPickDate={handlePickDate}
+          onHoverDate={setHoverDate}
+          onLeaveGrid={() => setHoverDate(null)}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1,9 +1,11 @@
 import Home from './pages/Home.jsx'
 import Info from './pages/Info.jsx'
 import Calculator from './pages/Calculator.jsx'
+import Calendar from './pages/Calendar.jsx'
 
 export const navRoutes = [
   { path: '/', label: 'Home', element: <Home /> },
   { path: '/info', label: 'Info', element: <Info /> },
   { path: '/calculator', label: 'Calculator', element: <Calculator /> },
+  { path: '/calendar', label: 'Calendar', element: <Calendar /> },
 ]


### PR DESCRIPTION
## Summary
- Add a new Calendar page and register it in sidebar navigation.
- Render two side-by-side month views with Prev/Next controls to shift both months.
- Implement date-range picking with reset-on-third-click behavior and display the selected range in a read-only text field.

## Test plan
- [x] Run `npm run build`

Closes #16