### PR TITLE
feat: Apartments page with image sliders (#25)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -351,3 +351,140 @@ body {
   visibility: hidden;
   pointer-events: none;
 }
+
+/* Apartments / image sliders (Issue #25) */
+.apartments-page {
+  max-width: 72rem;
+}
+
+.apartments-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
+  gap: 1.25rem;
+  align-items: stretch;
+}
+
+.apartment-card {
+  display: flex;
+  flex-direction: column;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+  min-width: 0;
+}
+
+.apartment-card-body {
+  padding: 1rem 1.1rem 1.15rem;
+  flex: 1;
+}
+
+.apartment-card-title {
+  margin: 0 0 0.5rem;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.apartment-card-desc {
+  margin: 0;
+  font-size: 0.9375rem;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.apartment-slider {
+  border-bottom: 1px solid var(--border);
+}
+
+.apartment-slider-frame {
+  position: relative;
+  aspect-ratio: 720 / 448;
+  background: var(--bg);
+}
+
+.apartment-slider-image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.apartment-slider-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.5rem 0.65rem;
+  flex-wrap: wrap;
+}
+
+.apartment-slider-btn {
+  margin: 0;
+  padding: 0.4rem 0.65rem;
+  font: inherit;
+  font-size: 0.875rem;
+  color: var(--text);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
+}
+
+.apartment-slider-btn:hover {
+  background: rgba(110, 181, 255, 0.1);
+  border-color: var(--accent-dim);
+}
+
+.apartment-slider-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.apartment-slider-btn--icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.25rem;
+  min-height: 2.25rem;
+  padding: 0.35rem;
+  font-size: 1.125rem;
+  font-weight: 600;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.apartment-slider-dots {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.apartment-slider-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: var(--border);
+  cursor: pointer;
+  transition: background 0.15s, transform 0.15s;
+}
+
+.apartment-slider-dot:hover {
+  background: var(--muted);
+}
+
+.apartment-slider-dot:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.apartment-slider-dot--active {
+  background: var(--accent);
+  transform: scale(1.15);
+}

--- a/src/pages/Apartments.jsx
+++ b/src/pages/Apartments.jsx
@@ -1,0 +1,118 @@
+import { useState } from 'react'
+
+const apartments = [
+  {
+    title: 'Harbor Loft',
+    description:
+      'Bright corner unit with floor-to-ceiling windows, a compact kitchen, and a small workspace nook. Ideal for two guests who want walkable cafés and evening waterfront strolls.',
+    images: [
+      'https://picsum.photos/seed/harbor-loft-1/720/448',
+      'https://picsum.photos/seed/harbor-loft-2/720/448',
+      'https://picsum.photos/seed/harbor-loft-3/720/448',
+      'https://picsum.photos/seed/harbor-loft-4/720/448',
+      'https://picsum.photos/seed/harbor-loft-5/720/448',
+    ],
+  },
+  {
+    title: 'Garden Studio',
+    description:
+      'Quiet ground-floor studio opening onto a shared courtyard. Includes laundry in the building, reliable Wi‑Fi, and simple self check-in for flexible arrival times.',
+    images: [
+      'https://picsum.photos/seed/garden-studio-1/720/448',
+      'https://picsum.photos/seed/garden-studio-2/720/448',
+      'https://picsum.photos/seed/garden-studio-3/720/448',
+      'https://picsum.photos/seed/garden-studio-4/720/448',
+      'https://picsum.photos/seed/garden-studio-5/720/448',
+    ],
+  },
+  {
+    title: 'Skyline One-Bedroom',
+    description:
+      'Elevated views, a separate bedroom, and a dining table for four. Great for longer stays: full-size fridge, dishwasher, and blackout shades in the bedroom.',
+    images: [
+      'https://picsum.photos/seed/skyline-bed-1/720/448',
+      'https://picsum.photos/seed/skyline-bed-2/720/448',
+      'https://picsum.photos/seed/skyline-bed-3/720/448',
+      'https://picsum.photos/seed/skyline-bed-4/720/448',
+      'https://picsum.photos/seed/skyline-bed-5/720/448',
+    ],
+  },
+]
+
+function ImageSlider({ title, images }) {
+  const [index, setIndex] = useState(0)
+  const count = images.length
+  const goPrev = () => setIndex((i) => (i - 1 + count) % count)
+  const goNext = () => setIndex((i) => (i + 1) % count)
+
+  return (
+    <div className="apartment-slider">
+      <div className="apartment-slider-frame">
+        <img
+          className="apartment-slider-image"
+          src={images[index]}
+          alt={`${title} — photo ${index + 1} of ${count}`}
+          width={720}
+          height={448}
+          loading={index === 0 ? 'eager' : 'lazy'}
+        />
+      </div>
+      <div className="apartment-slider-toolbar">
+        <button
+          type="button"
+          className="apartment-slider-btn apartment-slider-btn--icon"
+          onClick={goPrev}
+          aria-label="Previous photo"
+        >
+          {'<'}
+        </button>
+        <div className="apartment-slider-dots" role="tablist" aria-label="Photos">
+          {images.map((_, i) => (
+            <button
+              key={i}
+              type="button"
+              role="tab"
+              aria-selected={i === index}
+              aria-label={`Show photo ${i + 1}`}
+              className={
+                'apartment-slider-dot' + (i === index ? ' apartment-slider-dot--active' : '')
+              }
+              onClick={() => setIndex(i)}
+            />
+          ))}
+        </div>
+        <button
+          type="button"
+          className="apartment-slider-btn apartment-slider-btn--icon"
+          onClick={goNext}
+          aria-label="Next photo"
+        >
+          {'>'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default function Apartments() {
+  return (
+    <div className="page apartments-page">
+      <h1>Example stays</h1>
+      <p className="page-lead">
+        Three sample listings with short descriptions and photo carousels—similar to what a guest
+        would see when browsing apartments.
+      </p>
+      <div className="apartments-grid">
+        {apartments.map((apt) => (
+          <article key={apt.title} className="apartment-card">
+            <ImageSlider title={apt.title} images={apt.images} />
+            <div className="apartment-card-body">
+              <h2 className="apartment-card-title">{apt.title}</h2>
+              <p className="apartment-card-desc">{apt.description}</p>
+            </div>
+          </article>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -2,10 +2,12 @@ import Home from './pages/Home.jsx'
 import Info from './pages/Info.jsx'
 import Calculator from './pages/Calculator.jsx'
 import Calendar from './pages/Calendar.jsx'
+import Apartments from './pages/Apartments.jsx'
 
 export const navRoutes = [
   { path: '/', label: 'Home', element: <Home /> },
   { path: '/info', label: 'Info', element: <Info /> },
   { path: '/calculator', label: 'Calculator', element: <Calculator /> },
   { path: '/calendar', label: 'Calendar', element: <Calendar /> },
+  { path: '/apartments', label: 'Apartments', element: <Apartments /> },
 ]


### PR DESCRIPTION
## Summary
- Add Apartments page with per-unit image sliders and chevron navigation
- Register the Apartments route and extend global styles for the new page

## Test plan
- [ ] npm run build
- [ ] Manual: open the Apartments route and verify sliders and chevron controls

Closes #25