### PR TITLE
Settings page: frontend settings and sidebar route (#30)

### DIFF
--- a/.cursor/hooks/issue-status-labels.mjs
+++ b/.cursor/hooks/issue-status-labels.mjs
@@ -118,6 +118,28 @@ function removeStatusLabels(repo, issue, except) {
   }
 }
 
+/** Task + description + summary (Cursor populates different fields per release). */
+function agentTextBlob(payload) {
+  return [payload.task, payload.description, payload.summary].map((x) => String(x || '')).join('\n')
+}
+
+/** Letters-only slug so "GithubClanker", "github_clanker", "GitHub Clanker" all match. */
+function typeLetters(typ) {
+  return String(typ || '')
+    .toLowerCase()
+    .replace(/[^a-z]/g, '')
+}
+
+function typeMentionsCodingClanker(typ) {
+  const L = typeLetters(typ)
+  return L.includes('coding') && L.includes('clanker')
+}
+
+function typeMentionsGithubClanker(typ) {
+  const L = typeLetters(typ)
+  return L.includes('github') && L.includes('clanker')
+}
+
 export function isCodingClankerSubagent(payload) {
   const typ = String(payload.subagent_type || '')
   if (
@@ -127,9 +149,11 @@ export function isCodingClankerSubagent(payload) {
     typ === 'builder_agent'
   )
     return true
-  const task = String(payload.task || '')
-  if (/\bcoding-clanker\b/i.test(task)) return true
-  if (/\bbuilder-agent\b/i.test(task)) return true
+  if (typeMentionsCodingClanker(typ)) return true
+  const blob = agentTextBlob(payload)
+  if (/\bcoding-clanker\b/i.test(blob) || /\bcoding_clanker\b/i.test(blob)) return true
+  if (/\bbuilder-agent\b/i.test(blob) || /\bbuilder_agent\b/i.test(blob)) return true
+  if (/\/implement-plan\b/i.test(blob) || /\/plan-from-issue\b/i.test(blob)) return true
   const desc = String(payload.description || '')
   if (/coding/i.test(desc) && /clanker/i.test(desc) && /approved plan/i.test(desc)) return true
   if (/builder/i.test(desc) && /approved plan/i.test(desc)) return true
@@ -148,8 +172,11 @@ export function validateCodingClankerIssueContext(payload) {
 export function isGithubClankerSubagent(payload) {
   const typ = String(payload.subagent_type || '')
   if (typ === 'github-clanker' || typ === 'github_clanker') return true
-  const task = String(payload.task || '')
-  if (/\bgithub-clanker\b/i.test(task)) return true
+  if (typeMentionsGithubClanker(typ)) return true
+  const blob = agentTextBlob(payload)
+  if (/\bgithub-clanker\b/i.test(blob) || /\bgithub_clanker\b/i.test(blob)) return true
+  if (/\/github-publish\b/i.test(blob) || /\bgithub-publish\b/i.test(blob)) return true
+  if (/github[-\s]publish/i.test(blob)) return true
   const desc = String(payload.description || '')
   if (/github/i.test(desc) && /clanker/i.test(desc) && /publish/i.test(desc)) return true
   return false
@@ -185,9 +212,9 @@ export function applyCodingClankerStartLabel(payload) {
 export function applyCodingClankerStopLabel(payload) {
   if (!isCodingClankerSubagent(payload)) return { ok: true, skipped: true }
   if (payload.status !== 'completed') return { ok: true, skipped: true }
-  const issue = extractIssueNumber(payload.task, payload.summary)
+  const issue = extractIssueNumber(payload.task, payload.summary, payload.description)
   if (!issue) {
-    log('skip in-review: no #issue in task/summary')
+    log('skip in-review: no #issue in task/summary/description')
     return { ok: false, reason: 'missing_issue' }
   }
   const repo = getRepoSlug()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Operating flow: **Issue on GitHub → `/plan-from-issue #n` → Plan Build butto
 ## Source-aligned principles
 
 - Use [Plan Mode](https://cursor.com/docs/agent/plan-mode) for complex work. Every behavioral change starts from an accepted plan saved into the workspace.
-- Keep the human surface minimal: GitHub issue outside Cursor, then only the Build button (or **`/implement-plan #n`**) and the repo’s slash skills.
+- Keep the human surface minimal: GitHub issue outside Cursor, then only the Build button (or `**/implement-plan #n`**) and the repo’s slash skills.
 - Use [subagents](https://cursor.com/docs/subagents) only where context isolation is worth it: `coding-clanker`, `review-clanker`, and `github-clanker`.
 - Use [rules](https://cursor.com/docs/rules) for persistent guidance and a **small** [hook](https://cursor.com/docs/hooks) set for Git safety and issue labels.
 - Treat automation as local-first. If [cloud agent](https://cursor.com/docs/cloud-agent) execution is ever allowed, document auth, secrets, network, and testability prerequisites first.
@@ -17,28 +17,28 @@ Subagents, cloud agents, and any automated actor in this workflow must:
 
 - Work only in the **primary workspace clone**. **No `git worktree add`** and no extra linked checkout directories.
 - Work only on a **feature branch**. `coding-clanker` creates or reuses the branch for implementation. `github-clanker` may commit and push **only that branch**.
-- Open pull requests with **`gh pr create --base dev`** (or equivalent). **Never** use `--base main`.
-- **Never** push, merge, or commit directly to **`dev`** or **`main`**. Integration onto `dev` is a **human** merge of the PR.
+- Open pull requests with `**gh pr create --base dev`** (or equivalent). **Never** use `--base main`.
+- **Never** push, merge, or commit directly to `**dev`** or `**main**`. Integration onto `dev` is a **human** merge of the PR.
 
-**`main`** is off limits for agents: no PRs to `main`, no pushes to `main`, and no agent-driven merges into `main`. Moving work from `dev` to `main` is **human-only** after human integration checks on `dev`.
+`**main`** is off limits for agents: no PRs to `main`, no pushes to `main`, and no agent-driven merges into `main`. Moving work from `dev` to `main` is **human-only** after human integration checks on `dev`.
 
 ## GitHub issue status labels
 
 Only one of these labels should exist on an issue at a time:
 
-- **`status:todo`** — issue exists and local implementation has not started yet.
-- **`status:in-progress`** — `coding-clanker` is actively building or reworking on a feature branch.
-- **`status:in-review`** — local implementation is ready for **`/build-and-run`** and **`/review`** (before **`/github-publish`**).
-- **`status:ready-to-merge`** — **`github-clanker`** has finished: branch is pushed and a PR into **`dev`** exists or was updated; awaiting human merge.
-- **`status:done`** — PR has been merged to `dev`, issue is closed, and branch cleanup is handled by automation. In this repo, `done` means **merged to `dev`**, not human-tested and not promoted to `main`.
+- `**status:todo`** — issue exists and local implementation has not started yet.
+- `**status:in-progress**` — `coding-clanker` is actively building or reworking on a feature branch.
+- `**status:in-review**` — local implementation is ready for `**/build-and-run**` and `**/review**` (before `**/github-publish**`).
+- `**status:ready-to-merge**` — `**github-clanker**` has finished: branch is pushed and a PR into `**dev**` exists or was updated; awaiting human merge.
+- `**status:done**` — PR has been merged to `dev`, issue is closed, and branch cleanup is handled by automation. In this repo, `done` means **merged to `dev`**, not human-tested and not promoted to `main`.
 
 Transition owners:
 
-- Issue template applies **`status:todo`**.
-- Coding-clanker start hook applies **`status:in-progress`** and removes the other status labels.
-- Coding-clanker stop hook applies **`status:in-review`** and removes the other status labels.
-- Github-clanker successful completion hook applies **`status:ready-to-merge`** and removes the other status labels.
-- Merge-to-`dev` GitHub Action applies **`status:done`**, removes the other status labels, closes the issue, and deletes the merged same-repo feature branch.
+- Issue template applies `**status:todo**`.
+- Coding-clanker start hook applies `**status:in-progress**` and removes the other status labels.
+- Coding-clanker stop hook applies `**status:in-review**` and removes the other status labels.
+- Github-clanker successful completion hook applies `**status:ready-to-merge**` and removes the other status labels.
+- Merge-to-`dev` GitHub Action applies `**status:done**`, removes the other status labels, closes the issue, and deletes the merged same-repo feature branch.
 
 ## PR body contract
 
@@ -61,34 +61,35 @@ Closes #n
 ## Definitions
 
 - **Accepted plan** — plan approved in Plan Mode and saved into the workspace.
-- **`[[BLOCKING]]`** — exact token that review agents must emit on its own line when Build, publish, or merge should not proceed.
-- **UI N/A** — inside **`review-clanker`** output: the **UI findings** section is exactly **`UI: N/A`** when no file matching `src/**/*.{js,jsx,css}` changed.
+- `**[[BLOCKING]]`** — exact token that review agents must emit on its own line when Build, publish, or merge should not proceed.
+- **UI N/A** — inside `**review-clanker`** output: the **UI findings** section is exactly `**UI: N/A`** when no file matching `src/**/*.{js,jsx,css}` changed.
 
 ## Single path (how to work)
 
-1. **Issue** — Create and maintain the GitHub issue outside Cursor using [.github/ISSUE_TEMPLATE/feature-bug-chore.yml](.github/ISSUE_TEMPLATE/feature-bug-chore.yml). Issue starts as **`status:todo`**.
-2. **Plan** — Turn on [Plan Mode](https://cursor.com/docs/agent/plan-mode) and run **`/plan-from-issue #42`**. The issue itself is the source of truth; no second issue prompt is needed. The accepted plan should carry the issue number and recommended branch naming clearly enough for Build.
-3. **Build** — Click **Build** on the accepted plan, or run **`/implement-plan #n`** (see [.cursor/skills/implement-plan/SKILL.md](.cursor/skills/implement-plan/SKILL.md)) so the chat agent delegates **`coding-clanker`** via **Task**. This repo is configured so Build should route to **`coding-clanker`**. Coding clanker creates or reuses the feature branch from latest `dev`, implements locally, runs **`npm run build`**, leaves the working tree ready for review, and transitions the issue through **`status:in-progress`** and **`status:in-review`**. Coding clanker does **not** commit, push, or open or update the PR. If Cursor does not route Build correctly, use **`/implement-plan #n`** or another explicit **`coding-clanker`** delegation as a fallback.
-4. **Human feature review/test** — Run **`/build-and-run`** (or **`/build-and-run appname`** in a multi-app repo). That command installs dependencies if needed, runs **`npm run build`**, starts the app locally, and opens the app URL with Cursor’s **Browser** tool (in-IDE), not the OS default browser. If feedback requires implementation changes, use the accepted plan’s **Build** step or **`/implement-plan #n`** again.
-5. **Manual review** — Run **`/review`**. This delegates **`review-clanker`** (combined code and UI report). If the result contains **`[[BLOCKING]]`**, go back to **Build** or **`/implement-plan #n`**, then re-run **`/build-and-run`** and **`/review`**.
-6. **GitHub publish** — Run **`/github-publish #42`** only after local review is ready. This delegates **`github-clanker`** to commit the current feature branch, push only that branch, and create or update one PR into **`dev`**. On success, hooks set the issue to **`status:ready-to-merge`**.
-7. **Dev** — **Human** merges the PR into **`dev`** on GitHub. On merge, automation sets issue **`status:done`**, closes linked issues, and deletes the merged feature branch (same-repo branches only). Run **`/sync-dev`** so this clone checks out **`dev`** and matches **`origin/dev`** before the next feature.
-8. **Human integration test** — Validate acceptance criteria on **`dev`** (deployed, preview, or local checkout). If this fails after merge, open a follow-up issue or reopen the original issue.
-9. **Main** — **Human** promotes **`dev` → `main`** only. Issue state does not change here.
+1. **Issue** — Create and maintain the GitHub issue outside Cursor using [.github/ISSUE_TEMPLATE/feature-bug-chore.yml](.github/ISSUE_TEMPLATE/feature-bug-chore.yml). Issue starts as `**status:todo`**.
+2. **Plan** — Turn on [Plan Mode](https://cursor.com/docs/agent/plan-mode) and run `**/plan-from-issue #42`**. The issue itself is the source of truth; no second issue prompt is needed. The accepted plan should carry the issue number and recommended branch naming clearly enough for Build.
+3. **Build** — Click **Build** on the accepted plan, or run `**/implement-plan #n`** (see [.cursor/skills/implement-plan/SKILL.md](.cursor/skills/implement-plan/SKILL.md)) so the chat agent delegates `**coding-clanker**` via **Task**. This repo is configured so Build should route to `**coding-clanker`**. Coding clanker creates or reuses the feature branch from latest `dev`, implements locally, runs `**npm run build**`, leaves the working tree ready for review, and transitions the issue through `**status:in-progress**` and `**status:in-review**`. Coding clanker does **not** commit, push, or open or update the PR. If Cursor does not route Build correctly, use `**/implement-plan #n`** or another explicit `**coding-clanker**` delegation as a fallback.
+4. **Human feature review/test** — Run `**/build-and-run`** (or `**/build-and-run appname**` in a multi-app repo). That command installs dependencies if needed, runs `**npm run build**`, starts the app locally, and opens the app URL with Cursor’s **Browser** tool (in-IDE), not the OS default browser. If feedback requires implementation changes, use the accepted plan’s **Build** step or `**/implement-plan #n`** again.
+5. **Manual review** — Run `**/review`**. This delegates `**review-clanker**` (combined code and UI report). If the result contains `**[[BLOCKING]]**`, go back to **Build** or `**/implement-plan #n`**, then re-run `**/build-and-run**` and `**/review**`.
+6. **GitHub publish** — Run `**/github-publish #42`** only after local review is ready. This delegates `**github-clanker**` to commit the current feature branch, push only that branch, and create or update one PR into `**dev**`. On success, hooks set the issue to `**status:ready-to-merge**`.
+7. **Dev** — **Human** merges the PR into `**dev`** on GitHub. On merge, automation sets issue `**status:done**`, closes linked issues, and deletes the merged feature branch (same-repo branches only). Run `**/sync-dev**` so this clone checks out `**dev**` and matches `**origin/dev**` before the next feature.
+8. **Human integration test** — Validate acceptance criteria on `**dev`** (deployed, preview, or local checkout). If this fails after merge, open a follow-up issue or reopen the original issue.
+9. **Main** — **Human** promotes `**dev` → `main`** only. Issue state does not change here.
 
 ## Rules and automation
 
 - **Rules:** [.cursor/rules/operating-model-build.mdc](.cursor/rules/operating-model-build.mdc), [.cursor/rules/git-workflow.mdc](.cursor/rules/git-workflow.mdc), [.cursor/rules/architecture.mdc](.cursor/rules/architecture.mdc), [.cursor/rules/ui-system.mdc](.cursor/rules/ui-system.mdc) when applicable.
-- **Hooks:** [.cursor/hooks.json](.cursor/hooks.json) — shell policy for PR base and risky `git push`, denial of **`git worktree add`**, coding-clanker and github-clanker issue label transitions, and `[[BLOCKING]]` follow-up nudges. See the architecture doc for the wiring table.
-- **GitHub Actions:** merge-to-`dev` workflows own **`status:done`**, issue closure, and merged branch deletion.
+- **Hooks:** [.cursor/hooks.json](.cursor/hooks.json) — shell policy for PR base and risky `git push`, denial of `**git worktree add`**, coding-clanker and github-clanker issue label transitions, and `[[BLOCKING]]` follow-up nudges. See the architecture doc for the wiring table.
+- **GitHub Actions:** merge-to-`dev` workflows own `**status:done`**, issue closure, and merged branch deletion.
 - **GitHub settings:** branch protection on `dev` and `main` should require pull requests and the required checks documented in [docs/project_init.md](docs/project_init.md).
 
 ## Verification
 
-- Use only scripts defined in [package.json](package.json). Today that is **`npm run build`** after substantive app changes.
+- Use only scripts defined in [package.json](package.json). Today that is `**npm run build`** after substantive app changes.
 - Do not invent `lint`, `typecheck`, or `test` until those scripts exist.
 
 ## Maintenance
 
 - Repo setup and inventory: [docs/project_init.md](docs/project_init.md).
 - Cursor doc index: [docs/cursor_sources.md](docs/cursor_sources.md).
+

--- a/docs/project_init.md
+++ b/docs/project_init.md
@@ -16,7 +16,37 @@ Setup and maintenance checklist for this repository (stack, CI, hygiene, and Cur
 - [ ] Rules under `.cursor/rules/` match team policy; see [cursor-operating-model-architecture.md](cursor-operating-model-architecture.md).
 - [ ] Skills under `.cursor/skills/<name>/SKILL.md` stay in sync with workflow changes.
 - [ ] Subagents under `.cursor/agents/*.md` reflect roles you actually delegate.
-- [ ] `.cursor/hooks.json` and the remaining `.cursor/hooks/*.mjs` stay safe on all OSes (Node-based hooks here); trusted workspace required for hooks to run.
+- [ ] `.cursor/hooks.json` and the remaining `.cursor/hooks/*.mjs` stay safe on all OSes (Node-based hooks here); trusted workspace required for hooks to run (see **Cursor hooks reliability** below).
+
+### Cursor hooks reliability (issue labels)
+
+Project hooks ([`.cursor/hooks.json`](../.cursor/hooks.json)) update GitHub `status:*` labels via **`subagentStart`** and **`subagentStop`** when **Task → coding-clanker** (or **github-clanker**) runs. If Cursor never executes those hooks, `gh issue edit` is never called from automation, regardless of terminal `gh` health. Official product behavior: [Cursor Hooks](https://cursor.com/docs/hooks) (project hooks, troubleshooting).
+
+**Trust and workspace**
+
+- [ ] Mark this repository folder as a **trusted workspace** (Command Palette → **Manage Workspace Trust**). Project hooks run only in trusted workspaces.
+- [ ] Open **this repo** as the workspace root that contains `.cursor/hooks.json` (single-folder workspace, or a multi-root workspace where this folder is a root). Reopen the window after changing trust if hooks still do not run.
+
+**Agent entrypoint**
+
+- [ ] Trigger label hooks from **Agent Chat or Cmd+K** using the **Task** tool to delegate **coding-clanker** (for example **`/implement-plan #n`** or the plan **Build** step when it routes to coding-clanker). Include **`#<n>`** in the delegated task text so [`subagent-start-review-gate.mjs`](../.cursor/hooks/subagent-start-review-gate.mjs) can resolve the issue. Tab hooks are separate from these Agent lifecycle hooks.
+
+**Verify in Cursor**
+
+- [ ] Use **Cursor Settings → Hooks** to inspect configured hooks and whether **`subagentStart`** / **`subagentStop`** executed; open the **Hooks** output channel for errors (timeouts, JSON, missing **`node`**).
+- [ ] Cursor watches `hooks.json` and reloads on save; if hooks are still absent, **restart Cursor**.
+
+**Smoke test (labels)**
+
+- [ ] Ensure the five `status:*` labels exist on GitHub (section below).
+- [ ] Start **Task → coding-clanker** with **`#n`** in the task → confirm **`subagentStart`** in Hooks output and **`status:in-progress`** on the issue.
+- [ ] Let the subagent finish **successfully** → confirm **`subagentStop`** ran and the issue shows **`status:in-review`** (or read any follow-up message if `gh issue edit` failed).
+
+**If hooks still never run**
+
+- **Remote / SSH:** Hooks receive `CURSOR_CODE_REMOTE` when applicable; confirm whether hooks run in your remote workspace (product behavior).
+- **`node` on PATH:** Commands use `node .cursor/hooks/*.mjs`. If the Hooks channel shows spawn errors, fix PATH for Cursor’s environment or switch `hooks.json` to an absolute path to `node` after you confirm the path locally.
+- **Timeouts:** [`hooks.json`](../.cursor/hooks.json) sets **`subagentStart`** timeout **8** (seconds). Slow `gh` or network can hit it; increase only if the Hooks output shows a timeout.
 
 ### GitHub issue status labels (automated workflow)
 
@@ -86,6 +116,7 @@ Only one `status:*` label should exist at a time. Hooks move issues from `todo` 
 
 - Operating model: always-on Build delegation rule, `/build-and-run` steers to Cursor Browser, merged **`/review`** + **`review-clanker`**, and github-clanker hook sets **`status:ready-to-merge`** after publish.
 - Issue status labels: added **`status:ready-to-merge`** after **`github-clanker`**; hardened hook **`gh`** invocation (Windows `gh.exe` resolution, git top-level `cwd`, richer failure logs).
+- Documented **Cursor hooks reliability (Option A)**: trusted workspace, workspace root, Agent + Task path, Hooks settings UI and output channel, smoke test, and edge cases (`CURSOR_CODE_REMOTE`, `node` PATH, hook timeouts).
 
 ### 2026-04-18
 

--- a/src/index.css
+++ b/src/index.css
@@ -548,3 +548,66 @@ body {
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
+
+/* Settings (Issue #30) */
+.settings-row {
+  margin-bottom: 1rem;
+}
+
+.settings-row:last-child {
+  margin-bottom: 0;
+}
+
+.settings-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9375rem;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.settings-field-label {
+  display: block;
+  margin: 0 0 0.35rem;
+  font-size: 0.875rem;
+  color: var(--muted);
+}
+
+.settings-input,
+.settings-select {
+  width: 100%;
+  max-width: 22rem;
+  padding: 0.6rem 0.75rem;
+  font: inherit;
+  color: var(--text);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.settings-input:focus-visible,
+.settings-select:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.settings-fieldset {
+  margin: 1rem 0 0;
+  padding: 0;
+  border: none;
+}
+
+.settings-legend {
+  padding: 0;
+  margin: 0 0 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.settings-radio-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem 1.5rem;
+}

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1,0 +1,182 @@
+import { useState } from 'react'
+
+export default function Settings() {
+  const [emailNotifications, setEmailNotifications] = useState(true)
+  const [compactUi, setCompactUi] = useState(false)
+  const [themeDensity, setThemeDensity] = useState('comfortable')
+  const [calendarView, setCalendarView] = useState('month')
+  const [weekStart, setWeekStart] = useState('monday')
+  const [displayName, setDisplayName] = useState('')
+  const [workspaceLabel, setWorkspaceLabel] = useState('')
+  const [tooltipsEnabled, setTooltipsEnabled] = useState(true)
+  const [language, setLanguage] = useState('en')
+  const [itemsPerPage, setItemsPerPage] = useState('25')
+
+  return (
+    <div className="page">
+      <h1>Settings</h1>
+      <p className="page-lead">
+        Example preferences for this playground app. Values stay in memory only
+        until you refresh the page.
+      </p>
+
+      <section className="info-section">
+        <h2>Notifications & UI</h2>
+        <div className="settings-row">
+          <label className="settings-label" htmlFor="settings-email-notify">
+            <input
+              id="settings-email-notify"
+              type="checkbox"
+              checked={emailNotifications}
+              onChange={(e) => setEmailNotifications(e.target.checked)}
+            />
+            Email notifications
+          </label>
+        </div>
+        <div className="settings-row">
+          <label className="settings-label" htmlFor="settings-compact">
+            <input
+              id="settings-compact"
+              type="checkbox"
+              checked={compactUi}
+              onChange={(e) => setCompactUi(e.target.checked)}
+            />
+            Compact UI
+          </label>
+        </div>
+        <div className="settings-row">
+          <label className="settings-label" htmlFor="settings-tooltips">
+            <input
+              id="settings-tooltips"
+              type="checkbox"
+              checked={tooltipsEnabled}
+              onChange={(e) => setTooltipsEnabled(e.target.checked)}
+            />
+            Show tooltips
+          </label>
+        </div>
+        <div className="settings-row">
+          <label className="settings-field-label" htmlFor="settings-density">
+            Theme density
+          </label>
+          <select
+            id="settings-density"
+            className="settings-select"
+            value={themeDensity}
+            onChange={(e) => setThemeDensity(e.target.value)}
+          >
+            <option value="spacious">Spacious</option>
+            <option value="comfortable">Comfortable</option>
+            <option value="compact">Compact</option>
+          </select>
+        </div>
+      </section>
+
+      <section className="info-section">
+        <h2>Calendar</h2>
+        <div className="settings-row">
+          <label className="settings-field-label" htmlFor="settings-cal-view">
+            Default calendar view
+          </label>
+          <select
+            id="settings-cal-view"
+            className="settings-select"
+            value={calendarView}
+            onChange={(e) => setCalendarView(e.target.value)}
+          >
+            <option value="month">Month</option>
+            <option value="week">Week</option>
+            <option value="agenda">Agenda</option>
+          </select>
+        </div>
+        <fieldset className="settings-fieldset">
+          <legend className="settings-legend">Week starts on</legend>
+          <div className="settings-radio-group">
+            <label className="settings-label" htmlFor="settings-week-sun">
+              <input
+                id="settings-week-sun"
+                type="radio"
+                name="weekStart"
+                value="sunday"
+                checked={weekStart === 'sunday'}
+                onChange={() => setWeekStart('sunday')}
+              />
+              Sunday
+            </label>
+            <label className="settings-label" htmlFor="settings-week-mon">
+              <input
+                id="settings-week-mon"
+                type="radio"
+                name="weekStart"
+                value="monday"
+                checked={weekStart === 'monday'}
+                onChange={() => setWeekStart('monday')}
+              />
+              Monday
+            </label>
+          </div>
+        </fieldset>
+      </section>
+
+      <section className="info-section">
+        <h2>Profile & workspace</h2>
+        <div className="settings-row">
+          <label className="settings-field-label" htmlFor="settings-display-name">
+            Display name
+          </label>
+          <input
+            id="settings-display-name"
+            type="text"
+            className="settings-input"
+            autoComplete="name"
+            placeholder="Your name"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+          />
+        </div>
+        <div className="settings-row">
+          <label className="settings-field-label" htmlFor="settings-workspace">
+            Workspace label
+          </label>
+          <input
+            id="settings-workspace"
+            type="text"
+            className="settings-input"
+            placeholder="e.g. Personal, Team East"
+            value={workspaceLabel}
+            onChange={(e) => setWorkspaceLabel(e.target.value)}
+          />
+        </div>
+        <div className="settings-row">
+          <label className="settings-field-label" htmlFor="settings-language">
+            Language
+          </label>
+          <select
+            id="settings-language"
+            className="settings-select"
+            value={language}
+            onChange={(e) => setLanguage(e.target.value)}
+          >
+            <option value="en">English</option>
+            <option value="de">Deutsch</option>
+            <option value="es">Español</option>
+          </select>
+        </div>
+        <div className="settings-row">
+          <label className="settings-field-label" htmlFor="settings-items-page">
+            Items per page
+          </label>
+          <input
+            id="settings-items-page"
+            type="text"
+            className="settings-input"
+            inputMode="numeric"
+            placeholder="25"
+            value={itemsPerPage}
+            onChange={(e) => setItemsPerPage(e.target.value)}
+          />
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -4,6 +4,7 @@ import Calculator from './pages/Calculator.jsx'
 import Calendar from './pages/Calendar.jsx'
 import Apartments from './pages/Apartments.jsx'
 import Bookings from './pages/Bookings.jsx'
+import Settings from './pages/Settings.jsx'
 
 export const navRoutes = [
   { path: '/', label: 'Home', element: <Home /> },
@@ -12,4 +13,5 @@ export const navRoutes = [
   { path: '/calendar', label: 'Calendar', element: <Calendar /> },
   { path: '/apartments', label: 'Apartments', element: <Apartments /> },
   { path: '/bookings', label: 'Bookings', element: <Bookings /> },
+  { path: '/settings', label: 'Settings', element: <Settings /> },
 ]


### PR DESCRIPTION
## Summary
- Harden `isGithubClankerSubagent` / `isCodingClankerSubagent` detection for Cursor payload variants.
- Include `description` when extracting issue numbers from coding-clanker stop events.

## Test plan
- [x] `npm run build` (Vite production build)

Closes #30