### PR TITLE
docs: add /create-issue skill and align workflow documentation

### DIFF
--- a/.cursor/rules/git-workflow.mdc
+++ b/.cursor/rules/git-workflow.mdc
@@ -14,7 +14,7 @@ alwaysApply: false
 
 ## Human command surface
 
-- The intended human workflow is: issue outside Cursor, **`/plan-from-issue #n`**, the accepted plan’s **Build** button, **`/build-and-run [app]`**, **`/review`**, and **`/github-publish #n`**. After the PR is merged into **`dev`** on GitHub, run **`/sync-dev`** to fetch, check out local **`dev`**, and pull **`origin/dev`** before the next feature.
+- The intended human workflow is: GitHub issue (**`/create-issue feature|bug|chore …`** or the web UI), **`/plan-from-issue #n`**, the accepted plan’s **Build** button, **`/build-and-run [app]`**, **`/review`**, and **`/github-publish #n`**. After the PR is merged into **`dev`** on GitHub, run **`/sync-dev`** to fetch, check out local **`dev`**, and pull **`origin/dev`** before the next feature.
 - Cursor does **not** expose a repo-local way to hard-bind the Build button to a named subagent. This repo therefore steers Build toward **`coding-clanker`** with rules, plan handoff wording, and subagent descriptions.
 
 ## No Git worktrees (hard rule)

--- a/.cursor/skills/create-issue/SKILL.md
+++ b/.cursor/skills/create-issue/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: create-issue
+description: >-
+  Creates a GitHub issue from the user's rough idea using the same fields and
+  labels as the repo's issue form. Use when the user runs `/create-issue
+  feature`, `/create-issue bug`, or `/create-issue chore` (or equivalent) with
+  a short description, or asks to file an issue that matches the feature-bug-chore
+  template.
+disable-model-invocation: true
+---
+
+# Create issue
+
+## When to use
+
+- The user runs **`/create-issue feature`**, **`/create-issue bug`**, or **`/create-issue chore`** followed by a rough idea.
+- They want an issue on GitHub that matches [.github/ISSUE_TEMPLATE/feature-bug-chore.yml](@.github/ISSUE_TEMPLATE/feature-bug-chore.yml) (Type dropdown, Issue body scaffold, `status:todo`).
+
+## Preconditions
+
+- **`gh`** is installed and authenticated (`gh auth status` shows a logged-in user with access to the repo).
+- Default repo is **`origin`** on GitHub. If the user names another `owner/repo`, pass **`gh issue create -R owner/repo`**.
+
+`gh issue create --template` applies to **markdown** templates, not this **YAML** form. Recreate the form contract with **`--title`**, **`--body`** (or **`--body-file`**), and **`--label status:todo`**.
+
+## Parse input
+
+1. **Type** — first token after the command: **`feature`**, **`bug`**, or **`chore`** (case-insensitive). Map to **`Feature`**, **`Bug`**, **`Chore`** (exact casing for the body).
+2. **Rough idea** — remainder of the user message. If missing, ask once for a one-line description.
+3. **Repo** — optional `-R owner/repo` when the user specifies it or `origin` is not the target.
+
+## Draft issue
+
+**Title:** concise, imperative, specific (never the template placeholder `Title`).
+
+**Body** — Markdown mirroring a submitted issue form for that YAML (field labels from the form):
+
+```markdown
+### Type
+
+<Feature|Bug|Chore>
+
+### Issue
+
+## Problem / Goal
+<from rough idea>
+
+## Expected Outcome
+<infer or keep brief placeholder if unknown>
+
+## Acceptance Criteria (rough)
+- [ ] <derive from idea where obvious>
+- [ ] 
+
+## Context
+<links, notes, or leave a short placeholder>
+```
+
+Use the **`##`** headings and checklist style from the template’s textarea default. Fill from the rough idea; use minimal placeholders only where the user gave no signal.
+
+**Labels:** always **`--label status:todo`** (matches the template). Do not drop this label on error; fix auth or label configuration instead.
+
+## Create on GitHub
+
+1. From the **workspace git root**, ensure the default remote is correct (`git remote -v`).
+2. Write the body to a **temporary file** (UTF-8), then run:
+
+   ```bash
+   gh issue create --title "<title>" --body-file "<path-to-temp-file>" --label "status:todo"
+   ```
+
+   Add **`-R owner/repo`** when applicable.
+
+   Prefer **`--body-file`** over inline **`--body`** so multi-line Markdown works on **Windows PowerShell** without quoting failures.
+
+3. Delete the temp file after success (or on failure if it contains no secrets—body is user-provided).
+
+4. Print the **issue URL** and **`#n`** so the human can run **`/plan-from-issue #n`** (see [AGENTS.md](@AGENTS.md)).
+
+## Failure handling
+
+- Surface **`gh`** stderr. Common fixes: **`gh auth login`**, **`gh auth refresh`**, wrong repo (`-R`), or missing **`status:todo`** label on the GitHub repo.
+- Do not create the issue without **`status:todo`** unless the user explicitly overrides in the same thread.
+
+## References
+
+- Issue form: [.github/ISSUE_TEMPLATE/feature-bug-chore.yml](@.github/ISSUE_TEMPLATE/feature-bug-chore.yml)
+- Workflow: [AGENTS.md](@AGENTS.md)

--- a/.cursor/skills/implement-plan/SKILL.md
+++ b/.cursor/skills/implement-plan/SKILL.md
@@ -15,7 +15,7 @@ Use this skill only to delegate **[coding-clanker](@.cursor/agents/coding-clanke
 ## When to use
 
 - An **accepted plan** exists (saved in the workspace or clearly summarized in the thread).
-- The GitHub issue **`#n`** is the source of truth for scope and acceptance criteria.
+- The GitHub issue **`#n`** is the source of truth for scope and acceptance criteria. If no issue exists yet, create one with **`/create-issue`** (see [.cursor/skills/create-issue/SKILL.md](@.cursor/skills/create-issue/SKILL.md)) or the web UI before planning.
 - The human runs **`/implement-plan #n`** (or equivalent wording with the issue number).
 
 ## Inputs

--- a/.cursor/skills/plan-from-issue/SKILL.md
+++ b/.cursor/skills/plan-from-issue/SKILL.md
@@ -8,7 +8,7 @@ disable-model-invocation: true
 
 ## When to use
 
-- A GitHub issue already exists and contains the implementation details.
+- A GitHub issue already exists and contains the implementation details. If there is no issue yet, create one with **`/create-issue`** (see [.cursor/skills/create-issue/SKILL.md](@.cursor/skills/create-issue/SKILL.md)) or the web UI using the same template.
 - The human wants planning to be as short as possible: **`/plan-from-issue #123`** and nothing more.
 - Use with [AGENTS.md](@AGENTS.md): turn on [Plan mode](https://cursor.com/docs/agent/plan-mode), then run this skill.
 
@@ -34,6 +34,7 @@ disable-model-invocation: true
 
 ## References
 
+- Creating issues: [.cursor/skills/create-issue/SKILL.md](@.cursor/skills/create-issue/SKILL.md)
 - Issue template: [.github/ISSUE_TEMPLATE/feature-bug-chore.yml](@.github/ISSUE_TEMPLATE/feature-bug-chore.yml)
 - Architecture: [.cursor/rules/architecture.mdc](@.cursor/rules/architecture.mdc)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,11 @@
 # Project Instructions
 
-Operating flow: **Issue on GitHub → `/plan-from-issue #n` → Plan Build button or `/implement-plan #n` → `coding-clanker` → `/build-and-run [app]` → `/review` → `/github-publish #n` → merge to `dev` → `/sync-dev` → human integration test → merge to `main`.** The canonical workflow contract lives here. Wiring and enforcement details live in [docs/cursor-operating-model-architecture.md](docs/cursor-operating-model-architecture.md). Command examples live in [docs/operating-model-tutorial.md](docs/operating-model-tutorial.md). Official Cursor product references are indexed in [docs/cursor_sources.md](docs/cursor_sources.md).
+Operating flow: **Issue on GitHub** (GitHub UI or **`/create-issue`**) → **`/plan-from-issue #n`** → Plan Build button or **`/implement-plan #n`** → **`coding-clanker`** → **`/build-and-run [app]`** → **`/review`** → **`/github-publish #n`** → merge to **`dev`** → **`/sync-dev`** → human integration test → merge to **`main`**. The canonical workflow contract lives here. Wiring and enforcement details live in [docs/cursor-operating-model-architecture.md](docs/cursor-operating-model-architecture.md). Command examples live in [docs/operating-model-tutorial.md](docs/operating-model-tutorial.md). Official Cursor product references are indexed in [docs/cursor_sources.md](docs/cursor_sources.md).
 
 ## Source-aligned principles
 
 - Use [Plan Mode](https://cursor.com/docs/agent/plan-mode) for complex work. Every behavioral change starts from an accepted plan saved into the workspace.
-- Keep the human surface minimal: GitHub issue outside Cursor, then only the Build button (or `**/implement-plan #n`**) and the repo’s slash skills.
+- Keep the human surface minimal: GitHub issue (**`/create-issue`** or the web UI), then only the Build button (or `**/implement-plan #n`**) and the repo’s slash skills.
 - Use [subagents](https://cursor.com/docs/subagents) only where context isolation is worth it: `coding-clanker`, `review-clanker`, and `github-clanker`.
 - Use [rules](https://cursor.com/docs/rules) for persistent guidance and a **small** [hook](https://cursor.com/docs/hooks) set for Git safety and issue labels.
 - Treat automation as local-first. If [cloud agent](https://cursor.com/docs/cloud-agent) execution is ever allowed, document auth, secrets, network, and testability prerequisites first.
@@ -66,7 +66,7 @@ Closes #n
 
 ## Single path (how to work)
 
-1. **Issue** — Create and maintain the GitHub issue outside Cursor using [.github/ISSUE_TEMPLATE/feature-bug-chore.yml](.github/ISSUE_TEMPLATE/feature-bug-chore.yml). Issue starts as `**status:todo`**.
+1. **Issue** — Create on GitHub with **`/create-issue feature`**, **`/create-issue bug`**, or **`/create-issue chore`** plus a rough idea (see [.cursor/skills/create-issue/SKILL.md](.cursor/skills/create-issue/SKILL.md)), or use the template in the web UI [.github/ISSUE_TEMPLATE/feature-bug-chore.yml](.github/ISSUE_TEMPLATE/feature-bug-chore.yml). Issue starts as `**status:todo`**.
 2. **Plan** — Turn on [Plan Mode](https://cursor.com/docs/agent/plan-mode) and run `**/plan-from-issue #42`**. The issue itself is the source of truth; no second issue prompt is needed. The accepted plan should carry the issue number and recommended branch naming clearly enough for Build.
 3. **Build** — Click **Build** on the accepted plan, or run `**/implement-plan #n`** (see [.cursor/skills/implement-plan/SKILL.md](.cursor/skills/implement-plan/SKILL.md)) so the chat agent delegates `**coding-clanker**` via **Task**. This repo is configured so Build should route to `**coding-clanker`**. Coding clanker creates or reuses the feature branch from latest `dev`, implements locally, runs `**npm run build**`, leaves the working tree ready for review, and transitions the issue through `**status:in-progress**` and `**status:in-review**`. Coding clanker does **not** commit, push, or open or update the PR. If Cursor does not route Build correctly, use `**/implement-plan #n`** or another explicit `**coding-clanker**` delegation as a fallback.
 4. **Human feature review/test** — Run `**/build-and-run`** (or `**/build-and-run appname**` in a multi-app repo). That command installs dependencies if needed, runs `**npm run build**`, starts the app locally, and opens the app URL with Cursor’s **Browser** tool (in-IDE), not the OS default browser. If feedback requires implementation changes, use the accepted plan’s **Build** step or `**/implement-plan #n`** again.

--- a/docs/cursor-operating-model-architecture.md
+++ b/docs/cursor-operating-model-architecture.md
@@ -15,7 +15,7 @@ Official Cursor docs used for this repo:
 Repo decisions derived from those docs:
 
 - Use **Plan Mode** for complex work and save accepted plans into the workspace.
-- Keep the human-visible surface minimal: GitHub issue, `**/plan-from-issue #n`**, the accepted plan as context, `**/implement-plan #n`**, `**/build-and-run**`, `**/review**`, `**/github-publish #n**`, and `**/sync-dev**` after merge to `**dev**` on GitHub.
+- Keep the human-visible surface minimal: GitHub issue (**`/create-issue`** or the web UI), `**/plan-from-issue #n`**, the accepted plan as context, `**/implement-plan #n`**, `**/build-and-run**`, `**/review**`, `**/github-publish #n**`, and `**/sync-dev**` after merge to `**dev**` on GitHub.
 - Use **subagents** only where context isolation is clearly worth it: `coding-clanker`, `review-clanker`, and `github-clanker`.
 - Keep **hooks** minimal: Git safety plus coding-clanker and github-clanker issue label automation.
 - Treat automation as **local-first**. If cloud execution is introduced later, document auth, secrets, network, and testability prerequisites first.
@@ -46,7 +46,7 @@ Hooks enforce part of this via `beforeShellExecution` and coding-clanker label h
 
 ```mermaid
 flowchart LR
-  issue["Issue outside Cursor"] --> plan["/plan-from-issue #n"]
+  issueStart["Issue (UI or /create-issue)"] --> plan["/plan-from-issue #n"]
   plan --> impl["/implement-plan #n"]
   impl --> coding[CodingClanker]
   coding --> run["/build-and-run [app]"]
@@ -71,7 +71,7 @@ Only one issue status label should exist at a time:
 
 | Label                   | Meaning                                                                                       | Owner                        |
 | ----------------------- | --------------------------------------------------------------------------------------------- | ---------------------------- |
-| `status:todo`           | Issue exists and `**coding-clanker**` has not started yet (`**/implement-plan**` not run yet) | Issue template               |
+| `status:todo`           | Issue exists and `**coding-clanker**` has not started yet (`**/implement-plan**` not run yet) | Issue template or **`/create-issue`** |
 | `status:in-progress`    | `coding-clanker` is actively building or reworking on a feature branch                        | Coding-clanker start hook    |
 | `status:in-review`      | Local implementation is ready for `/build-and-run` and `/review` (before `/github-publish`)   | Coding-clanker stop hook     |
 | `status:ready-to-merge` | PR into `dev` is pushed and open/updated; awaiting human merge                                | Github-clanker stop hook     |
@@ -111,7 +111,7 @@ Enforcement stance:
 | Workflow contract         | [AGENTS.md](../AGENTS.md)                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | Git/PR rule               | [.cursor/rules/git-workflow.mdc](../.cursor/rules/git-workflow.mdc)                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | Architecture/UI rules     | [.cursor/rules/architecture.mdc](../.cursor/rules/architecture.mdc), [.cursor/rules/ui-system.mdc](../.cursor/rules/ui-system.mdc)                                                                                                                                                                                                                                                                                                                                                               |
-| Visible skills            | [.cursor/skills/plan-from-issue/SKILL.md](../.cursor/skills/plan-from-issue/SKILL.md), [.cursor/skills/implement-plan/SKILL.md](../.cursor/skills/implement-plan/SKILL.md), [.cursor/skills/build-and-run/SKILL.md](../.cursor/skills/build-and-run/SKILL.md), [.cursor/skills/review/SKILL.md](../.cursor/skills/review/SKILL.md), [.cursor/skills/github-publish/SKILL.md](../.cursor/skills/github-publish/SKILL.md), [.cursor/skills/sync-dev/SKILL.md](../.cursor/skills/sync-dev/SKILL.md) |
+| Visible skills            | [.cursor/skills/create-issue/SKILL.md](../.cursor/skills/create-issue/SKILL.md), [.cursor/skills/plan-from-issue/SKILL.md](../.cursor/skills/plan-from-issue/SKILL.md), [.cursor/skills/implement-plan/SKILL.md](../.cursor/skills/implement-plan/SKILL.md), [.cursor/skills/build-and-run/SKILL.md](../.cursor/skills/build-and-run/SKILL.md), [.cursor/skills/review/SKILL.md](../.cursor/skills/review/SKILL.md), [.cursor/skills/github-publish/SKILL.md](../.cursor/skills/github-publish/SKILL.md), [.cursor/skills/sync-dev/SKILL.md](../.cursor/skills/sync-dev/SKILL.md) |
 | Subagents                 | [.cursor/agents/*.md](../.cursor/agents/)                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | Local hooks               | [.cursor/hooks/*.mjs](../.cursor/hooks/) + [.cursor/hooks.json](../.cursor/hooks.json)                                                                                                                                                                                                                                                                                                                                                                                                           |
 | Merge-to-`dev` automation | [.github/workflows/issue-status-on-pr-merge.yml](../.github/workflows/issue-status-on-pr-merge.yml), [.github/workflows/delete-feature-branch-on-merge.yml](../.github/workflows/delete-feature-branch-on-merge.yml)                                                                                                                                                                                                                                                                             |

--- a/docs/cursor-system-overview.md
+++ b/docs/cursor-system-overview.md
@@ -23,9 +23,9 @@ Use it to understand how the repo maps Cursor product concepts to local files. T
 
 ## Repo operating model at a glance
 
-Issue outside Cursor → `/plan-from-issue #n` → `/implement-plan #n` → `/build-and-run [app]` → `/review` → `/github-publish #n` → Dev (merge on GitHub) → `/sync-dev` → Human integration test → Main
+Issue (GitHub UI or `/create-issue`) → `/plan-from-issue #n` → `/implement-plan #n` → `/build-and-run [app]` → `/review` → `/github-publish #n` → Dev (merge on GitHub) → `/sync-dev` → Human integration test → Main
 
-- **Issue** starts as `status:todo`; when `**coding-clanker`** starts (from `**/implement-plan**`), hooks set `status:in-progress`, then `status:in-review` when it finishes successfully; after `**/github-publish**` completes successfully, hooks set `status:ready-to-merge` until merge to `dev`
+- **Issue** starts as `status:todo` (issue form on GitHub or **`/create-issue`**); when `**coding-clanker`** starts (from `**/implement-plan**`), hooks set `status:in-progress`, then `status:in-review` when it finishes successfully; after `**/github-publish**` completes successfully, hooks set `status:ready-to-merge` until merge to `dev`
 - **Implementation** is `**/implement-plan #n`** → **Task** → `coding-clanker`. Cursor’s Plan **Build** button (if used) is only steerable via rules, not hard-bound from the repo (see [cursor-operating-model-architecture.md](cursor-operating-model-architecture.md))
 - `**/build-and-run`** installs if needed, runs `npm run build`, starts the app, and opens the local URL with Cursor’s **Browser** tool (in-IDE)
 - `**/review`** delegates `review-clanker` (code + UI; `**UI: N/A**` when no UI files changed)

--- a/docs/operating-model-tutorial.md
+++ b/docs/operating-model-tutorial.md
@@ -1,6 +1,6 @@
 # Operating model tutorial (minimal commands)
 
-This repo is designed so the human only uses the GitHub issue, the accepted plan as context, `**/implement-plan #n**` for implementation, and a small set of slash skills.
+This repo is designed so the human only uses the GitHub issue (`**/create-issue**` or the web UI), the accepted plan as context, `**/implement-plan #n**` for implementation, and a small set of slash skills.
 
 Replace `#42` with your issue number everywhere it appears.
 
@@ -11,7 +11,7 @@ Hooks update `**status:***` labels on the linked issue when `**coding-clanker**`
 
 | When                                                               | Label                        |
 | ------------------------------------------------------------------ | ---------------------------- |
-| Issue created (template)                                           | `status:todo`                |
+| Issue created (template or `**/create-issue**`)                    | `status:todo`                |
 | `**coding-clanker` starts** (`**/implement-plan`**)                | `status:in-progress`         |
 | `**coding-clanker` finishes successfully**                         | `status:in-review`           |
 | `**github-clanker` finishes successfully** (`**/github-publish`**) | `status:ready-to-merge`      |
@@ -20,9 +20,18 @@ Hooks update `**status:***` labels on the linked issue when `**coding-clanker**`
 
 ## 1. Issue
 
-Create the issue outside Cursor using [.github/ISSUE_TEMPLATE/feature-bug-chore.yml](../.github/ISSUE_TEMPLATE/feature-bug-chore.yml).
+Either:
 
-**Issue status:** the template applies `**status:todo`**.
+- Run `**/create-issue feature**`, `**/create-issue bug**`, or `**/create-issue chore**` with a rough idea (see [.cursor/skills/create-issue/SKILL.md](../.cursor/skills/create-issue/SKILL.md); requires authenticated `**gh**`), or
+- Create the issue in the GitHub web UI using [.github/ISSUE_TEMPLATE/feature-bug-chore.yml](../.github/ISSUE_TEMPLATE/feature-bug-chore.yml).
+
+Example (replace the trailing text with your idea):
+
+```text
+/create-issue feature Short description of the change
+```
+
+**Issue status:** the template and `**/create-issue`** both apply `**status:todo`**.
 
 ## 2. Plan
 
@@ -48,7 +57,7 @@ See [.cursor/skills/implement-plan/SKILL.md](../.cursor/skills/implement-plan/SK
 
 If review sends work back for changes, run `**/implement-plan #42`** again on the same plan and branch.
 
-**Issue status:** when `**coding-clanker` starts**, hooks set `**status:in-progress`**. When it **finishes successfully**, hooks set `**status:in-review`**.
+**Issue status:** when `**coding-clanker` starts**, hooks set `**status:in-progress`**. When it finishes successfully, hooks set `**status:in-review`**.
 
 ## 4. Human feature review/test
 
@@ -98,11 +107,11 @@ Merge the PR into `dev` in GitHub.
 
 Expected post-merge automation:
 
-- issue gets `**status:done**`
+- issue gets `**status:done`**
 - issue closes
 - merged same-repo feature branch is deleted
 
-**Issue status:** merge-to-`**dev`** automation applies `**status:done**`, removes other `**status:***` labels, and closes the linked issue.
+**Issue status:** merge-to-`**dev`** automation applies `**status:done`**, removes other `**status:*`** labels, and closes the linked issue.
 
 ## 8. Sync local `dev` (after merge)
 
@@ -128,15 +137,15 @@ git pull origin dev
 
 Validate behavior on `dev` after merge.
 
-If integration fails after merge, open a follow-up issue or reopen the original issue.
+If integration fails after merge, open a follow-up issue (`**/create-issue`** or the web UI) or reopen the original issue.
 
-**Issue status:** new or reopened issues use the template (`**status:todo`**) again as needed.
+**Issue status:** new or reopened issues use `**status:todo`** again as needed.
 
 ## 10. Main
 
 Merge `dev` to `main` in GitHub as a human-only step.
 
-**Issue status:** no change from merge to `**main`** in this repo’s automation ( `**status:done**` still means merged to `**dev**` ).
+**Issue status:** no change from merge to `**main`** in this repo’s automation ( `**status:done`** still means merged to `**dev`** ).
 
 ## Rework loop
 
@@ -147,11 +156,12 @@ If `**/review**` returns `**[[BLOCKING]]**`:
 3. Re-run `**/review**`.
 4. Use `**/github-publish #42**` only after the branch is ready.
 
-**Issue status:** each successful `**coding-clanker`** pass again moves `**in-progress` → `in-review**`. Each successful `**/github-publish**` again sets `**ready-to-merge**` when `**github-clanker**` completes.
+**Issue status:** each successful `**coding-clanker`** pass again moves `**in-progress` → `in-review`**. Each successful `**/github-publish`** again sets `**ready-to-merge**` when `**github-clanker**` completes.
 
 ## See also
 
 - [AGENTS.md](../AGENTS.md) — canonical workflow contract
+- [.cursor/skills/create-issue/SKILL.md](../.cursor/skills/create-issue/SKILL.md) — `**/create-issue**` from Cursor
 - [cursor-operating-model-architecture.md](cursor-operating-model-architecture.md) — components, hooks, and enforcement map
 - [cursor-system-overview.md](cursor-system-overview.md) — short index of repo-to-product mapping
 

--- a/docs/project_init.md
+++ b/docs/project_init.md
@@ -97,7 +97,7 @@ Only one `status:*` label should exist at a time. Hooks move issues from `todo` 
 |------|--------|
 | Agent instructions | [AGENTS.md](../AGENTS.md) |
 | Project rules | `.cursor/rules/operating-model-build.mdc`, `.cursor/rules/ui-system.mdc`, `.cursor/rules/architecture.mdc`, `.cursor/rules/git-workflow.mdc` |
-| Skills | `.cursor/skills/plan-from-issue/`, `build-and-run/`, `review/`, `github-publish/`, `sync-dev/` (each contains `SKILL.md`) |
+| Skills | `.cursor/skills/create-issue/`, `plan-from-issue/`, `build-and-run/`, `review/`, `github-publish/`, `sync-dev/` (each contains `SKILL.md`) |
 | Subagents | `.cursor/agents/coding-clanker.md`, `review-clanker.md`, `github-clanker.md` |
 | Hooks | `.cursor/hooks.json`, `shell-policy.mjs`, `subagent-start-review-gate.mjs`, `subagent-stop-review-loop.mjs`, `issue-status-labels.mjs` |
 | Architecture map | [docs/cursor-operating-model-architecture.md](cursor-operating-model-architecture.md) |
@@ -107,13 +107,14 @@ Only one `status:*` label should exist at a time. Hooks move issues from `todo` 
 ### Notes
 
 - No `lint`, `typecheck`, or `test` script is installed yet.
-- The visible human workflow is: GitHub issue outside Cursor, `/plan-from-issue #n`, the accepted plan’s Build button, `/build-and-run`, `/review`, `/github-publish #n`, then merge on GitHub and `/sync-dev` locally.
+- The visible human workflow is: GitHub issue (`/create-issue feature|bug|chore …` or the web UI), `/plan-from-issue #n`, the accepted plan’s Build button, `/build-and-run`, `/review`, `/github-publish #n`, then merge on GitHub and `/sync-dev` locally.
 - `coding-clanker` owns implementation, `review-clanker` is report-only, and `github-clanker` owns commit, push, and PR publication. If cloud execution is introduced later, document auth, secrets, network, and testability prerequisites before relying on it.
 
 ## Change Log
 
 ### 2026-04-19
 
+- Documented **`/create-issue`** (slash skill + `gh issue create`) in [operating-model-tutorial.md](operating-model-tutorial.md), [cursor-system-overview.md](cursor-system-overview.md), and [.cursor/rules/git-workflow.mdc](../.cursor/rules/git-workflow.mdc); aligned **`plan-from-issue`** references and status-label owner text in [cursor-operating-model-architecture.md](cursor-operating-model-architecture.md).
 - Operating model: always-on Build delegation rule, `/build-and-run` steers to Cursor Browser, merged **`/review`** + **`review-clanker`**, and github-clanker hook sets **`status:ready-to-merge`** after publish.
 - Issue status labels: added **`status:ready-to-merge`** after **`github-clanker`**; hardened hook **`gh`** invocation (Windows `gh.exe` resolution, git top-level `cwd`, richer failure logs).
 - Documented **Cursor hooks reliability (Option A)**: trusted workspace, workspace root, Agent + Task path, Hooks settings UI and output channel, smoke test, and edge cases (`CURSOR_CODE_REMOTE`, `node` PATH, hook timeouts).


### PR DESCRIPTION
Made-with: Cursor

## Summary

- What changed?
- Why was it needed?
- Keep this section current after each push so reviewers always see the latest scope.

## Test plan

- [ ] `npm run build`
- [ ] `/build-and-run` completed locally
- [ ] Other relevant checks, if applicable

## Issue

Closes #<issue-number>

## UI Notes

- [ ] No UI changes
- [ ] UI changed and screenshots are included

## Follow-ups

- List any intentional follow-up work or leave `None`.
