### PR TITLE
fix(hooks): read payload.prompt for issue number in status label hooks

### DIFF
--- a/.cursor/hooks/issue-status-labels.mjs
+++ b/.cursor/hooks/issue-status-labels.mjs
@@ -118,9 +118,11 @@ function removeStatusLabels(repo, issue, except) {
   }
 }
 
-/** Task + description + summary (Cursor populates different fields per release). */
+/** Task + prompt + description + summary (Cursor populates different fields per release). */
 function agentTextBlob(payload) {
-  return [payload.task, payload.description, payload.summary].map((x) => String(x || '')).join('\n')
+  return [payload.task, payload.prompt, payload.description, payload.summary]
+    .map((x) => String(x || ''))
+    .join('\n')
 }
 
 /** Letters-only slug so "GithubClanker", "github_clanker", "GitHub Clanker" all match. */
@@ -162,7 +164,12 @@ export function isCodingClankerSubagent(payload) {
 
 export function validateCodingClankerIssueContext(payload) {
   if (!isCodingClankerSubagent(payload)) return { ok: true, issue: null, repo: null }
-  const issue = extractIssueNumber(payload.task, payload.description, payload.summary)
+  const issue = extractIssueNumber(
+    payload.task,
+    payload.prompt,
+    payload.description,
+    payload.summary
+  )
   if (!issue) return { ok: false, reason: 'missing_issue' }
   const repo = getRepoSlug()
   if (!repo) return { ok: false, reason: 'missing_repo', issue }
@@ -187,7 +194,12 @@ export function isGithubClankerSubagent(payload) {
  */
 export function applyCodingClankerStartLabel(payload) {
   if (!isCodingClankerSubagent(payload)) return { ok: true, skipped: true }
-  const issue = extractIssueNumber(payload.task, payload.description, payload.summary)
+  const issue = extractIssueNumber(
+    payload.task,
+    payload.prompt,
+    payload.description,
+    payload.summary
+  )
   if (!issue) {
     log('skip in-progress: no #issue in task')
     return { ok: false, reason: 'missing_issue' }
@@ -212,7 +224,12 @@ export function applyCodingClankerStartLabel(payload) {
 export function applyCodingClankerStopLabel(payload) {
   if (!isCodingClankerSubagent(payload)) return { ok: true, skipped: true }
   if (payload.status !== 'completed') return { ok: true, skipped: true }
-  const issue = extractIssueNumber(payload.task, payload.summary, payload.description)
+  const issue = extractIssueNumber(
+    payload.task,
+    payload.prompt,
+    payload.summary,
+    payload.description
+  )
   if (!issue) {
     log('skip in-review: no #issue in task/summary/description')
     return { ok: false, reason: 'missing_issue' }
@@ -237,7 +254,12 @@ export function applyCodingClankerStopLabel(payload) {
 export function applyGithubClankerStopLabel(payload) {
   if (!isGithubClankerSubagent(payload)) return { ok: true, skipped: true }
   if (payload.status !== 'completed') return { ok: true, skipped: true }
-  const issue = extractIssueNumber(payload.task, payload.summary, payload.description)
+  const issue = extractIssueNumber(
+    payload.task,
+    payload.prompt,
+    payload.summary,
+    payload.description
+  )
   if (!issue) {
     log('skip ready-to-merge: no #issue in task/summary/description')
     return { ok: false, reason: 'missing_issue' }

--- a/.cursor/hooks/subagent-start-review-gate.mjs
+++ b/.cursor/hooks/subagent-start-review-gate.mjs
@@ -20,11 +20,20 @@ try {
 }
 
 const type = payload.subagent_type || ''
-const task = String(payload.task || '').slice(0, 200)
-console.error(`[subagentStart] type=${type} task=${task}`)
+console.error(
+  `[subagentStart] type=${type} keys=${Object.keys(payload).join(',')} ` +
+    `task=${String(payload.task || '').slice(0, 120)} ` +
+    `prompt=${String(payload.prompt || '').slice(0, 120)} ` +
+    `desc=${String(payload.description || '').slice(0, 120)}`
+)
 
 if (isCodingClankerSubagent(payload)) {
-  const issue = extractIssueNumber(payload.task, payload.description)
+  const issue = extractIssueNumber(
+    payload.task,
+    payload.prompt,
+    payload.description,
+    payload.summary
+  )
   if (!issue) {
     process.stdout.write(
       JSON.stringify({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Fix GitHub status label automation so `status:todo` transitions to `status:in-progress` at `coding-clanker` start and to `status:in-review` on successful stop. `github-clanker` stop to `status:ready-to-merge` is fixed by the same change.
- Root cause: Cursor Task subagent payloads carry the delegation text in `payload.prompt`, but the hooks only inspected `payload.task` / `payload.description`, so `extractIssueNumber` returned null and label updates were skipped with `missing_issue`.
- `.cursor/hooks/issue-status-labels.mjs`: `agentTextBlob` now includes `payload.prompt`; all four `extractIssueNumber(...)` call sites (`validateCodingClankerIssueContext`, `applyCodingClankerStartLabel`, `applyCodingClankerStopLabel`, `applyGithubClankerStopLabel`) also pass `payload.prompt`.
- `.cursor/hooks/subagent-start-review-gate.mjs`: issue extraction includes `payload.prompt`; the `[subagentStart]` log line now prints payload keys plus truncated `task`/`prompt`/`description` so the Hooks output channel makes future debugging trivial.

## Test plan

- [x] `node --check` passes for all three hook scripts.
- [x] Sanity check: calling `isCodingClankerSubagent` and `validateCodingClankerIssueContext` with a `{ subagent_type: "coding-clanker", prompt: "Build Issue #34" }` payload returns `true` and `{ ok: true, issue: 34, repo: "devkfmn/playground" }`.
- [ ] Manual verification in Cursor: Task -> `coding-clanker` with `#n` only in the prompt flips the issue to `status:in-progress`, successful stop flips to `status:in-review`, and `/github-publish #n` flips to `status:ready-to-merge`.
- [ ] Hooks output channel shows the new `[subagentStart]` diagnostic line.

## Issue

Closes #34

## UI Notes

- [x] No UI changes

## Follow-ups

- None. Host-agnostic repo detection (GHE support) is intentionally out of scope; origin is github.com and `getRepoSlug` already resolves it.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6c27231-8c15-4eae-b8cc-0958b17a7d55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6c27231-8c15-4eae-b8cc-0958b17a7d55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

