### PR TITLE
feat: light/dark color theme and Settings toggle (#37)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,26 @@
+import { useEffect, useState } from 'react'
 import { Routes, Route, NavLink } from 'react-router-dom'
 import { navRoutes } from './routes.jsx'
 import { cn } from './cn.js'
+import Settings from './pages/Settings.jsx'
+
+const THEME_STORAGE_KEY = 'playground-theme'
 
 export default function App() {
+  const [theme, setTheme] = useState(() => {
+    const raw = document.documentElement.dataset.theme
+    return raw === 'light' || raw === 'dark' ? raw : 'dark'
+  })
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme
+    try {
+      localStorage.setItem(THEME_STORAGE_KEY, theme)
+    } catch {
+      /* ignore */
+    }
+  }, [theme])
+
   return (
     <div className="flex min-h-screen">
       <aside className="w-[220px] shrink-0 border-r border-border bg-surface py-5">
@@ -31,8 +49,18 @@ export default function App() {
       </aside>
       <main className="min-h-0 flex-1 overflow-auto px-10 py-8">
         <Routes>
-          {navRoutes.map(({ path, element }) => (
-            <Route key={path} path={path} element={element} />
+          {navRoutes.map(({ path, Component }) => (
+            <Route
+              key={path}
+              path={path}
+              element={
+                Component === Settings ? (
+                  <Settings theme={theme} setTheme={setTheme} />
+                ) : (
+                  <Component />
+                )
+              }
+            />
           ))}
         </Routes>
       </main>

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,7 @@
 @theme {
   --font-sans: 'Segoe UI', system-ui, -apple-system, sans-serif;
 
+  /* Dark defaults (also used when `data-theme` is absent or `dark`) */
   --color-bg: #0f1419;
   --color-surface: #1a2332;
   --color-border: #2d3a4d;
@@ -10,6 +11,16 @@
   --color-muted: #8b9cb3;
   --color-accent: #6eb5ff;
   --color-accent-dim: #4a8fd4;
+}
+
+:root[data-theme='light'] {
+  --color-bg: #f4f6fb;
+  --color-surface: #ffffff;
+  --color-border: #d8dee8;
+  --color-fg: #121826;
+  --color-muted: #5c6b80;
+  --color-accent: #2563eb;
+  --color-accent-dim: #1d4ed8;
 }
 
 @layer base {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,20 @@ import { BrowserRouter } from 'react-router-dom'
 import App from './App.jsx'
 import './index.css'
 
+const THEME_STORAGE_KEY = 'playground-theme'
+
+function readInitialTheme() {
+  try {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY)
+    if (stored === 'light' || stored === 'dark') return stored
+  } catch {
+    /* ignore (e.g. private mode) */
+  }
+  return 'dark'
+}
+
+document.documentElement.dataset.theme = readInitialTheme()
+
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <BrowserRouter>

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -6,7 +6,7 @@ const inputLike =
 const checkLabel =
   'inline-flex cursor-pointer items-center gap-2 text-[0.9375rem] text-fg'
 
-export default function Settings() {
+export default function Settings({ theme, setTheme }) {
   const [emailNotifications, setEmailNotifications] = useState(true)
   const [compactUi, setCompactUi] = useState(false)
   const [themeDensity, setThemeDensity] = useState('comfortable')
@@ -22,8 +22,8 @@ export default function Settings() {
     <div className="max-w-2xl">
       <h1 className="mb-3 text-[1.75rem] font-semibold">Settings</h1>
       <p className="mb-6 text-[1.05rem] leading-normal text-muted [&_strong]:text-fg">
-        Example preferences for this playground app. Values stay in memory only until you refresh
-        the page.
+        Example preferences for this playground app. Most options stay in memory only until you
+        refresh; <strong>color theme</strong> (dark or light) is saved in this browser.
       </p>
 
       <section className="mb-7">
@@ -60,6 +60,20 @@ export default function Settings() {
             />
             Show tooltips
           </label>
+        </div>
+        <div className="mb-4">
+          <label className={fieldLabel} htmlFor="settings-color-theme">
+            Color theme
+          </label>
+          <select
+            id="settings-color-theme"
+            className={inputLike}
+            value={theme}
+            onChange={(e) => setTheme(e.target.value)}
+          >
+            <option value="dark">Dark</option>
+            <option value="light">Light</option>
+          </select>
         </div>
         <div className="mb-0">
           <label className={fieldLabel} htmlFor="settings-density">

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -8,12 +8,12 @@ import PaymentMethods from './pages/PaymentMethods.jsx'
 import Settings from './pages/Settings.jsx'
 
 export const navRoutes = [
-  { path: '/', label: 'Home', element: <Home /> },
-  { path: '/info', label: 'Info', element: <Info /> },
-  { path: '/calculator', label: 'Calculator', element: <Calculator /> },
-  { path: '/calendar', label: 'Calendar', element: <Calendar /> },
-  { path: '/apartments', label: 'Apartments', element: <Apartments /> },
-  { path: '/bookings', label: 'Bookings', element: <Bookings /> },
-  { path: '/payment-methods', label: 'Payment methods', element: <PaymentMethods /> },
-  { path: '/settings', label: 'Settings', element: <Settings /> },
+  { path: '/', label: 'Home', Component: Home },
+  { path: '/info', label: 'Info', Component: Info },
+  { path: '/calculator', label: 'Calculator', Component: Calculator },
+  { path: '/calendar', label: 'Calendar', Component: Calendar },
+  { path: '/apartments', label: 'Apartments', Component: Apartments },
+  { path: '/bookings', label: 'Bookings', Component: Bookings },
+  { path: '/payment-methods', label: 'Payment methods', Component: PaymentMethods },
+  { path: '/settings', label: 'Settings', Component: Settings },
 ]


### PR DESCRIPTION
## Summary
- Add a light color palette in `index.css` and drive theming with `data-theme` on the document element (`light` or `dark`).
- Read the saved theme in `main.jsx` before first paint, keep `App` in sync, and persist changes to `localStorage`.
- Add a Color theme control on Settings; refactor `navRoutes` to pass component types so Settings can receive `theme` / `setTheme`.

## Test plan
- [ ] Run `npm run build` and confirm it succeeds
- [ ] Open Settings, switch between Dark and Light, reload, and confirm the choice persists

Closes #37