### PR TITLE
chore: refine Cursor workflow rules and publish skill

### DIFF
--- a/.cursor/rules/02-github-issues.mdc
+++ b/.cursor/rules/02-github-issues.mdc
@@ -1,0 +1,40 @@
+---
+description: GitHub issue lifecycle status policy
+alwaysApply: true
+---
+
+# GitHub Issues
+
+## Issue Status Lifecycle
+
+- `status:todo`: issue exists, work not prepared.
+- `status:in-planning`: issue prepared for planning.
+- `status:in-progress`: implementation running or incomplete.
+- `status:ready-to-review`: implementation complete and ready for review.
+- `status:ready-to-publish`: review passed; ready for PR creation.
+- `status:ready-to-merge`: PR exists and is ready for human merge.
+
+## Status Transitions
+
+- `create-issue` MUST create issues with `status:todo`.
+- `prepare-issue` MUST replace the current status label with `status:in-planning`.
+- Build MUST replace the current status label with `status:in-progress` when implementation starts.
+- Build MUST replace the current status label with `status:ready-to-review` only when implementation is complete and no known blocker remains.
+- `review-issue` MUST replace `status:ready-to-review` with `status:ready-to-publish` when review passes.
+- `review-issue` MUST replace the current status label with `status:in-progress` when review finds blockers.
+- `publish-issue` MUST replace `status:ready-to-publish` with `status:ready-to-merge` after PR creation.
+- Human merge MUST close the issue through GitHub.
+
+## Status Label Rules
+
+- Exactly one `status:*` label MUST be present at a time.
+- When changing status, the previous `status:*` label MUST be removed before adding the new one.
+- Additional status labels MUST NOT be invented unless the user explicitly requests them.
+- `status:ready-to-review` MUST NOT be set if implementation failed, blockers remain, checks failed, or acceptance criteria are incomplete.
+- `status:ready-to-publish` MUST NOT be set if review found blockers.
+- `status:ready-to-merge` MUST NOT be set before a PR exists.
+
+## Issue Comments
+
+- Important planning notes, blockers, review results, implementation summaries, and PR links SHOULD be added as issue comments.
+- Comments SHOULD be concise and useful.

--- a/.cursor/rules/03-design-system.mdc
+++ b/.cursor/rules/03-design-system.mdc
@@ -1,0 +1,31 @@
+---
+description: Enforce design-system source-of-truth usage for UI changes
+alwaysApply: true
+---
+
+# Design System Usage
+
+## Design-system source
+
+- If `docs/design/design-system.md` exists, read it before planning, implementing, or reviewing UI changes.
+- Treat `docs/design/design-system.md` as the source of truth for visual direction, colors, typography, spacing, components, patterns, interaction behavior, and UI quality standards.
+- Do not invent a new visual direction unless the user explicitly requests a redesign.
+
+## Mandatory behavior for UI work
+
+- Reuse existing components, tokens, styles, and patterns before creating new ones.
+- Preserve the existing design language unless the issue explicitly asks to change it.
+- Do not introduce random colors, spacing, typography, shadows, radii, animations, or component variants.
+- Do not add a new UI library unless the user explicitly approves it.
+- Keep UI changes scoped to the current issue or branch intent.
+- When changing shared UI, check likely affected usages.
+
+## UI review behavior
+
+- If UI files changed, review the result against `docs/design/design-system.md`.
+- Check accessibility, touch and interaction behavior, responsive layout, typography, spacing, color usage, component consistency, forms and feedback, and loading/error/empty states.
+- Flag deviations from the design system unless they are intentional and explained.
+
+## Fallback
+
+- If `docs/design/design-system.md` does not exist, use conservative generic UI polish and tell the user that a design-system document would improve consistency.

--- a/.cursor/skills/prepare-issue/SKILL.md
+++ b/.cursor/skills/prepare-issue/SKILL.md
@@ -12,6 +12,7 @@ Given an issue reference like `prepare-issue #23`, prepare planning context and 
 ## Behavior Rules
 
 - Do not ask clarifying questions.
+- Exception: if current branch is not `dev`, ask exactly one branch-state question with options and wait for user choice.
 - Do not implement code.
 - Do not modify project files except Git branch state.
 - Operate in a project-agnostic way. Do not assume any specific stack, product, architecture, or infrastructure.
@@ -32,16 +33,22 @@ Given an issue reference like `prepare-issue #23`, prepare planning context and 
   - where acceptance criteria live in the issue body
 3. Read the issue from GitHub via `gh`.
 4. Map extracted issue content according to the current template structure.
-5. Check out local `dev`.
-6. Sync local `dev` with remote `dev`.
-7. Create a new feature branch from `dev`.
-8. Name the branch using:
+5. Check current branch.
+  - If already on `dev`, continue.
+  - If not on `dev`, ask what to do and stop until user chooses one option:
+    - Move current changes to a new branch, then continue with `dev`.
+    - Continue anyway by switching to `dev` directly.
+    - Abort and stay on the current branch.
+6. Check out local `dev`.
+7. Sync local `dev` with remote `dev`.
+8. Create a new feature branch from `dev`.
+9. Name the branch using:
   - issue number
   - short slug derived from issue title (lowercase, hyphen-separated, alphanumeric plus hyphens)
   - example format: `feature/23-short-title`
-9. Replace the current status label with `status:in-planning` (do not stack status labels).
-10. Generate and show a Plan Mode prompt for the user to paste.
-11. Stop.
+10. Replace the current status label with `status:in-planning` (do not stack status labels).
+11. Generate and show a Plan Mode prompt for the user to paste.
+12. Stop.
 
 ## Failure Handling
 
@@ -51,6 +58,9 @@ Follow these guards exactly:
   - inform the user
   - abort
   - suggest checking issue number, `gh` authentication, or repository remote configuration
+- If current branch is not `dev` and user did not choose an option:
+  - inform the user
+  - pause and do not proceed
 - If checking out `dev` fails:
   - inform the user
   - abort
@@ -137,6 +147,7 @@ Always output a paste-ready prompt with these sections filled from the issue, cu
 - Current branch name
 - Instructions:
   - inspect the relevant codebase before planning
+  - if the issue touches UI, read `docs/design/design-system.md` before planning
   - during Plan Mode, do not implement code
   - during Plan Mode, produce a clear implementation plan
   - implementation happens later when the user clicks Build
@@ -189,16 +200,17 @@ Acceptance criteria:
 
 Instructions:
 1) Inspect the relevant codebase and current patterns before planning.
-2) During Plan Mode, do not write or modify code.
-3) During Plan Mode, produce a clear implementation plan.
-4) Implementation happens later when the user clicks Build.
-5) When Build starts, replace the related GitHub issue status label from `status:in-planning` to `status:in-progress`.
-6) When you believe implementation is complete:
+2) If the issue touches UI, read `docs/design/design-system.md` before planning.
+3) During Plan Mode, do not write or modify code.
+4) During Plan Mode, produce a clear implementation plan.
+5) Implementation happens later when the user clicks Build.
+6) When Build starts, replace the related GitHub issue status label from `status:in-planning` to `status:in-progress`.
+7) When you believe implementation is complete:
    - verify the acceptance criteria as far as possible
    - summarize what was implemented
    - replace the current status label with `status:ready-to-review`
    - add a structured GitHub issue comment saying implementation is ready for human review
-7) Do not set `status:ready-to-review` if implementation failed, blockers remain, checks fail, or important acceptance criteria are incomplete.
-8) If blocked or incomplete, keep `status:in-progress` and add a structured GitHub issue comment describing what is blocked or incomplete and the next action.
+8) Do not set `status:ready-to-review` if implementation failed, blockers remain, checks fail, or important acceptance criteria are incomplete.
+9) If blocked or incomplete, keep `status:in-progress` and add a structured GitHub issue comment describing what is blocked or incomplete and the next action.
 ```
 

--- a/.cursor/skills/prepare-vibe/SKILL.md
+++ b/.cursor/skills/prepare-vibe/SKILL.md
@@ -21,6 +21,7 @@ Prepare a safe feature branch for exploratory work when there is no existing Git
 - Do not implement code.
 - Do not modify project files except Git branch state.
 - Stop immediately after the branch is prepared and reported.
+- If current branch is not `dev`, ask exactly one branch-state question with options and wait for user choice before continuing.
 
 ## Workflow
 
@@ -28,20 +29,29 @@ Follow these steps in order. If a step fails, stop and apply the matching failur
 
 1. Identify topic input:
   - Parse optional topic text after `prepare-vibe`.
-2. Check out local `dev` branch.
-3. Sync local `dev` with remote `dev`:
+2. Check current branch.
+  - If already on `dev`, continue.
+  - If not on `dev`, ask what to do and stop until user chooses one option:
+    - Move current changes to a new branch, then continue with `dev`.
+    - Continue anyway by switching to `dev` directly.
+    - Abort and stay on the current branch.
+3. Check out local `dev` branch.
+4. Sync local `dev` with remote `dev`:
   - Fetch remote updates.
   - Fast-forward local `dev` to match `origin/dev` when possible.
-4. Build branch slug:
+5. Build branch slug:
   - If topic exists: convert topic to a short lowercase slug using letters, numbers, and hyphens.
   - If no topic: use a simple fallback such as `vibe/YYYY-MM-DD` or `vibe/scratch`.
-5. Create and check out the new branch from synced `dev`:
+6. Create and check out the new branch from synced `dev`:
   - Branch format: `vibe/<slug>`
-6. Verify current branch name.
-7. Stop.
+7. Verify current branch name.
+8. Stop.
 
 ## Failure Handling
 
+- If current branch is not `dev` and user did not choose an option:
+  - Inform the user and pause.
+  - Do not proceed with checkout/sync/branch creation.
 - If checking out `dev` fails:
   - Inform the user and abort.
   - Suggest checking whether `dev` exists locally or remotely.

--- a/.cursor/skills/publish-changes/SKILL.md
+++ b/.cursor/skills/publish-changes/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: open-pr
-description: Prepares the current branch for a GitHub pull request into dev with safety checks, commit/push workflow, and issue linking. Use when the user asks to open, create, or prepare a PR into dev.
+name: publish-changes
+description: Prepares the current branch for a GitHub pull request into dev with safety checks and commit/push workflow. Works for issue branches and vibe branches with no linked issue.
 ---
 
-# Open PR
+# Publish Changes
 
 ## Purpose
 
@@ -23,6 +23,7 @@ Prepare the current branch for a pull request into `dev`, create the PR, and sto
   - Detect the current branch.
   - Parse branch name and user prompt for an issue number like `#123` or `123` in issue-like contexts.
   - Track `related_issue` as optional.
+  - If no issue is found, continue in "no-linked-issue" mode (vibe-branch compatible).
 2. Branch safety checks
   - If branch is `main`: inform user, abort, suggest creating a feature branch first.
   - If branch is `dev` and user did not explicitly allow using `dev`: inform user, abort, suggest creating a feature or vibe branch first.
@@ -45,10 +46,11 @@ Prepare the current branch for a pull request into `dev`, create the PR, and sto
     - Changes made
     - Verification
     - Notes / risks
-  - If `related_issue` exists, include it explicitly in the PR body.
+  - If `related_issue` exists, include it explicitly in the PR body and add a closing keyword line: `Closes #<related_issue>`.
   - If PR creation fails: inform user, abort, suggest checking `gh` authentication/repository context or creating the PR manually.
 7. Issue follow-up (only when `related_issue` exists)
-  - Replace the current status label with `status:ready-to-merge` (do not stack status labels).
+  - Replace the current status label with `status:ready-to-merge` (do not stack status labels) after PR creation.
+  - If the issue is already `closed` when checked, replace the current status label with `status:done` instead.
   - Add an issue comment using a structured Markdown format (not a single-line sentence) containing the PR link and next action.
   - If issue update fails but PR exists: keep the PR and tell the user exactly which labels to remove, which status label to add, and that a comment with the PR link must be added manually.
 8. Stop
@@ -65,6 +67,7 @@ Use this structure:
 
 ## Related issue
 [Issue number/link, or "None"]
+[If present, also include: `Closes #<number>`]
 
 ## Changes made
 - [Change 1]
@@ -100,7 +103,7 @@ Use this structure:
   - Message: Check `gh` authentication/repository context or open PR manually.
 - Issue label/comment update fails
   - Action: Do not roll back PR.
-  - Message: Provide manual steps to replace the current status label with `status:ready-to-merge` and add an issue comment with PR link.
+  - Message: Provide manual steps to replace the current status label with `status:ready-to-merge` (or `status:done` if issue is already closed) and add an issue comment with PR link.
 
 ## GitHub CLI Usage
 
@@ -112,6 +115,7 @@ gh auth status
 ```
 
 If either check fails:
+
 - inform the user
 - abort
 - suggest running:
@@ -122,7 +126,7 @@ Use these commands where appropriate:
 
 ```bash
 gh pr create --base "dev" --head "<branch>" --title "<title>" --body "<body>"
-gh issue view <number> --json number,title,body,labels,url
+gh issue view <number> --json number,title,body,labels,url,state
 gh issue edit <number> --remove-label "<previous-status>" --add-label "status:ready-to-merge"
 gh issue comment <number> --body "$(cat <<'EOF'
 ## PR Ready To Merge
@@ -138,14 +142,22 @@ EOF
 )"
 ```
 
+If no `related_issue` exists, skip issue commands and continue with PR creation only.
+If `related_issue` exists, ensure the PR body contains `Closes #<number>` so GitHub closes it automatically on merge.
+
 Notes:
+
 - Supported status labels only:
   - `status:todo`
   - `status:in-planning`
   - `status:in-progress`
   - `status:ready-to-review`
   - `status:ready-to-merge`
+  - `status:done`
 - Always replace the previous `status:*` label instead of stacking.
+- Status policy:
+  - Use `status:ready-to-merge` after PR creation while issue is open.
+  - Use `status:done` when the issue is closed.
 - If a `gh` command fails, inform the user, abort when unsafe to continue, and suggest the most likely manual fix.
 
 ## Output Expectations
@@ -156,7 +168,7 @@ When successful, provide:
 - Base/head branches
 - Commit used
 - Whether an issue was linked
-- Whether issue label/comment updates succeeded
+- Whether issue label/comment updates succeeded (or `not applicable` when no issue is linked)
 
 When unsuccessful, provide:
 

--- a/.cursor/skills/review-issue/SKILL.md
+++ b/.cursor/skills/review-issue/SKILL.md
@@ -112,11 +112,14 @@ Failure handling:
 ### 5) Compare Implementation To Issue
 
 - Review issue requirements and acceptance criteria against the observed implementation.
+- If UI files changed, read `docs/design/design-system.md` and review the implementation against it.
+- Explicitly review UI-related changes against `.cursor/rules/03-design-system.mdc`.
 - Determine:
   - covered criteria
   - partially covered criteria
   - missing criteria
   - risks or ambiguities
+- For UI changes, record whether design-system usage is compliant, partially compliant, or non-compliant, including concrete evidence for any deviations.
 
 ### 6) Verification Commands
 
@@ -222,6 +225,7 @@ Always include:
 - acceptance criteria review
 - changed files summary
 - verification performed
+- design-system compliance review for UI-related changes (against `.cursor/rules/03-design-system.mdc`)
 - blockers or risks
 - next recommended action
 
@@ -241,6 +245,9 @@ Changed files summary:
 
 Verification performed:
 - <command>: <pass|fail|not run> - <notes>
+
+Design-system compliance (UI changes):
+- <compliant|partial|non-compliant> - <evidence and deviations>
 
 Blockers or risks:
 - <none|itemized blockers/risks>

--- a/.cursor/skills/review-vibe/SKILL.md
+++ b/.cursor/skills/review-vibe/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: review-vibe
+description: Reviews implementation changes for vibe branches before publishing, without issue workflows. Use when the user asks for review-vibe or requests a non-issue pre-PR review of local changes.
+---
+
+# Review Vibe
+
+## Goal
+
+Run a reusable, implementation-focused review step for non-issue work before opening a pull request.
+
+## Scope And Boundaries
+
+- Trigger only when explicitly requested as `review-vibe`.
+- Use GitHub CLI (`gh`) for GitHub checks if needed, but do not post comments or update issue labels.
+- Do not use GitHub MCP.
+- Do not implement new code unless the user explicitly asks for fixes after the review.
+- Do not create a pull request.
+- Do not merge anything.
+
+## Workflow
+
+1. Inspect local implementation context.
+2. Compare implementation against requested scope and branch intent.
+3. Run relevant verification commands.
+4. Decide review result: passed or blocked.
+5. Return a structured review summary and stop.
+
+## Step-By-Step Procedure
+
+### 1) Inspect Branch And Changes
+
+Inspect:
+
+```bash
+git branch --show-current
+git status --short
+git diff --name-only
+```
+
+Branch safety gate:
+
+- If current branch is `main` or `dev`, warn the user and abort unless the user explicitly confirms this is intended.
+
+Change inspection requirements:
+
+- Summarize changed files and high-level purpose.
+- Check whether branch name and changed files appear aligned with branch intent.
+- Check for obvious unrelated changes.
+
+Failure handling:
+
+- If changed files cannot be inspected, inform the user and abort.
+- On this failure, do not continue.
+
+### 2) Compare Implementation To Intent
+
+- Review user-requested scope and expected outcome against the observed implementation.
+- If UI files changed, read `docs/design/design-system.md` and review the implementation against it.
+- Explicitly review UI-related changes against `.cursor/rules/03-design-system.mdc`.
+- Determine:
+  - covered expectations
+  - partially covered expectations
+  - missing expectations
+  - risks or ambiguities
+- For UI changes, record whether design-system usage is compliant, partially compliant, or non-compliant, with concrete evidence for any deviations.
+
+### 3) Verification Commands
+
+- Run relevant repository verification commands when discoverable (for example test/lint/build commands defined in project docs or scripts).
+- If no reliable command is discoverable quickly, recommend the most relevant verification command(s) instead of inventing commands.
+
+Failure handling:
+
+- If verification commands fail, report the failure and treat it as a blocker unless the user explicitly says otherwise.
+
+### 4) Decide Result
+
+- **Passed**: no blockers, expected scope appears satisfied, and no critical verification failures.
+- **Blocked**: any blocker exists (missing expectations, critical risk, unrelated changes requiring cleanup, or verification failure not waived by user).
+
+### 5) Return Review Summary
+
+- Return a structured local review summary only.
+- Do not post GitHub comments.
+- Do not edit issue labels.
+
+## Safe-Stop Rules
+
+On any failure, do not continue to later steps unless it is explicitly safe.
+
+Safe examples:
+
+- Verification command missing: continue with explicit "not run" and recommendation.
+
+Unsafe examples:
+
+- Branch safety gate failed without user confirmation.
+- Change inspection failed.
+
+## Final Output Format
+
+Always include:
+
+- branch
+- review result: `passed` or `blocked`
+- expectations review
+- changed files summary
+- verification performed
+- design-system compliance review for UI-related changes (against `.cursor/rules/03-design-system.mdc`)
+- blockers or risks
+- next recommended action
+
+Use this template:
+
+```markdown
+Branch: <branch-name>
+Review result: <passed|blocked>
+
+Expectations review:
+- <expectation>: <covered|partial|missing> - <evidence>
+
+Changed files summary:
+- <area/file group>: <what changed>
+- Unrelated changes: <none|details>
+
+Verification performed:
+- <command>: <pass|fail|not run> - <notes>
+
+Design-system compliance (UI changes):
+- <compliant|partial|non-compliant> - <evidence and deviations>
+
+Blockers or risks:
+- <none|itemized blockers/risks>
+
+Next recommended action:
+- <single best next step>
+```


### PR DESCRIPTION
## Summary
- Add workflow governance for GitHub issue status lifecycle.
- Update prepare/review skills to incorporate design-system source-of-truth checks for UI work.
- Replace open-pr skill with a publish-changes workflow for safe PR creation.

## Related issue
None

## Changes made
- Added `.cursor/rules/02-github-issues.mdc` and refined `.cursor/rules/03-design-system.mdc`.
- Updated `.cursor/skills/prepare-issue/SKILL.md`, `.cursor/skills/prepare-vibe/SKILL.md`, and `.cursor/skills/review-issue/SKILL.md`.
- Added `.cursor/skills/review-vibe/SKILL.md` and renamed `open-pr` skill to `.cursor/skills/publish-changes/SKILL.md`.
- Added `docs/design/design-system.md` placeholder file.

## Verification
- `npm run build` (pass)
- Manual verification: `review-vibe` completed; identified follow-up risk for empty `docs/design/design-system.md`.

## Notes / risks
- `docs/design/design-system.md` is currently empty and should be populated to fully support the new UI review guidance.