### PR TITLE
Add polish-ui skill and expand design system docs

### DIFF
--- a/.cursor/skills/polish-ui/SKILL.md
+++ b/.cursor/skills/polish-ui/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: polish-ui
+description: Improves or recreates existing UI using the repository design system document as the single source of truth. Use when the user asks to polish, clean up, modernize, or visually improve a page, screen, component, or flow, or to recreate a page to match the design system—without changing product behavior unless they ask.
+---
+
+# Polish UI
+
+## Preconditions
+
+1. **Design system required**  
+   Read `docs/design/design-system.md` **before** editing UI.  
+   If that file does **not** exist: **stop**. Tell the user the design-system document is required for this skill and they should add it first.
+
+2. **Target**  
+   Identify the page, screen, component, or flow to polish. Inspect the current implementation (markup, styles, shared components, layout) before changing code.
+
+## Principles
+
+- **Source of truth:** All visual and pattern decisions align with `docs/design/design-system.md`.
+- **Preserve behavior:** Keep existing product behavior, data flow, routes, permissions, and business logic unless the user explicitly requests behavior changes.
+- **Reuse first:** Prefer existing components, tokens, styles, and patterns from the codebase and design system.
+- **Scope:** Limit edits to the chosen page, screen, component, or flow. No unrelated redesigns or a new visual direction.
+- **No new UI libraries** unless the user explicitly approves adding one.
+- **Do not change** backend logic, data models, API contracts, routing structure, or authentication unless explicitly requested.
+
+## What to improve
+
+When polishing or lightly recreating UI, improve where the design system supports it:
+
+- Visual hierarchy, layout, spacing, typography, alignment, component consistency  
+- Responsive behavior at common mobile and desktop widths  
+- Interaction and feedback states: loading, empty, error, disabled, hover, focus, active (where relevant)  
+- Accessibility basics: labels, focus visibility, keyboard use, contrast, accessible names for icon-only controls  
+
+## Recreating a page (layout / presentation)
+
+Keep the same functional purpose, core user actions, and required content and data. Restructure layout only when it improves clarity, usability, or design-system consistency. Replace inconsistent local styling with design-system-aligned components or patterns. Remove visual clutter when it is safe. Stay responsive and accessible as above.
+
+## Vague requests
+
+Pick the **smallest** relevant page, screen, component, or flow. Do **not** redesign the whole application. Ask **one short** clarification question only if the target UI cannot be identified.
+
+## Before finishing
+
+1. Re-check the result against `docs/design/design-system.md`.  
+2. Confirm behavior: preserved, or list explicit behavior changes.  
+3. Confirm scope: no unrelated files changed.  
+4. Where practical: responsive layout and basic accessibility states.
+
+**Closing summary for the user**
+
+- What was polished or recreated.  
+- Any behavior changes, or an explicit statement that behavior was preserved.  
+- Follow-ups intentionally left out of scope.
+
+## Failure and edge cases
+
+| Situation | Action |
+|-----------|--------|
+| `docs/design/design-system.md` missing | Abort; user must create it first. |
+| Target UI unclear | Ask which page, screen, component, or flow to polish (one short question). |
+| Implementation not found | Say so; ask for file path, route, or component name. |
+| Design system compliance would need behavior or architecture changes | Stop; ask before proceeding. |
+| Design system guidance ambiguous | Make the smallest conservative UI improvement; explain the ambiguity. |

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -1,0 +1,205 @@
+# Design System Master File
+
+
+---
+
+**Project:** Taurex
+**Generated:** 2026-04-30 22:26:59
+**Category:** SaaS (General)
+
+---
+
+## Global Rules
+
+### Color Palette
+
+| Role | Hex | CSS Variable |
+|------|-----|--------------|
+| Primary | `#1E40AF` | `--color-primary` |
+| On Primary | `#FFFFFF` | `--color-on-primary` |
+| Secondary | `#3B82F6` | `--color-secondary` |
+| Accent/CTA | `#D97706` | `--color-accent` |
+| Background | `#F8FAFC` | `--color-background` |
+| Foreground | `#1E3A8A` | `--color-foreground` |
+| Muted | `#E9EEF6` | `--color-muted` |
+| Border | `#DBEAFE` | `--color-border` |
+| Destructive | `#DC2626` | `--color-destructive` |
+| Ring | `#1E40AF` | `--color-ring` |
+
+**Color Notes:** Blue data + amber highlights [Accent adjusted from #F59E0B for WCAG 3:1]
+
+### Typography
+
+- **Heading Font:** Plus Jakarta Sans
+- **Body Font:** Plus Jakarta Sans
+- **Mood:** enterprise, saas, b2b, professional, indigo, modern, approachable, legible, ios dynamic type, android scaling
+- **Google Fonts:** [Plus Jakarta Sans + Plus Jakarta Sans](https://fonts.google.com/share?selection.family=Plus+Jakarta+Sans:ital,wght@0,400;0,600;0,700;0,800;1,400)
+
+**CSS Import:**
+```css
+@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,400;0,600;0,700;0,800;1,400&display=swap');
+```
+
+### Spacing Variables
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `--space-xs` | `4px` / `0.25rem` | Tight gaps |
+| `--space-sm` | `8px` / `0.5rem` | Icon gaps, inline spacing |
+| `--space-md` | `16px` / `1rem` | Standard padding |
+| `--space-lg` | `24px` / `1.5rem` | Section padding |
+| `--space-xl` | `32px` / `2rem` | Large gaps |
+| `--space-2xl` | `48px` / `3rem` | Section margins |
+| `--space-3xl` | `64px` / `4rem` | Hero padding |
+
+### Shadow Depths
+
+| Level | Value | Usage |
+|-------|-------|-------|
+| `--shadow-sm` | `0 1px 2px rgba(0,0,0,0.05)` | Subtle lift |
+| `--shadow-md` | `0 4px 6px rgba(0,0,0,0.1)` | Cards, buttons |
+| `--shadow-lg` | `0 10px 15px rgba(0,0,0,0.1)` | Modals, dropdowns |
+| `--shadow-xl` | `0 20px 25px rgba(0,0,0,0.15)` | Hero images, featured cards |
+
+---
+
+## Component Specs
+
+### Buttons
+
+```css
+/* Primary Button */
+.btn-primary {
+  background: #D97706;
+  color: white;
+  padding: 12px 24px;
+  border-radius: 8px;
+  font-weight: 600;
+  transition: all 200ms ease;
+  cursor: pointer;
+}
+
+.btn-primary:hover {
+  opacity: 0.9;
+  transform: translateY(-1px);
+}
+
+/* Secondary Button */
+.btn-secondary {
+  background: transparent;
+  color: #1E40AF;
+  border: 2px solid #1E40AF;
+  padding: 12px 24px;
+  border-radius: 8px;
+  font-weight: 600;
+  transition: all 200ms ease;
+  cursor: pointer;
+}
+```
+
+### Cards
+
+```css
+.card {
+  background: #F8FAFC;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: var(--shadow-md);
+  transition: all 200ms ease;
+  cursor: pointer;
+}
+
+.card:hover {
+  box-shadow: var(--shadow-lg);
+  transform: translateY(-2px);
+}
+```
+
+### Inputs
+
+```css
+.input {
+  padding: 12px 16px;
+  border: 1px solid #E2E8F0;
+  border-radius: 8px;
+  font-size: 16px;
+  transition: border-color 200ms ease;
+}
+
+.input:focus {
+  border-color: #1E40AF;
+  outline: none;
+  box-shadow: 0 0 0 3px #1E40AF20;
+}
+```
+
+### Modals
+
+```css
+.modal-overlay {
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+}
+
+.modal {
+  background: white;
+  border-radius: 16px;
+  padding: 32px;
+  box-shadow: var(--shadow-xl);
+  max-width: 500px;
+  width: 90%;
+}
+```
+
+---
+
+## Style Guidelines
+
+**Style:** SaaS Mobile (High-Tech Boutique)
+
+**Keywords:** saas, electric blue, gradient, fintech, spring animation, dual font, glassmorphism, boutique, premium, calistoga, inter, mono, tactile, haptic, bento
+
+**Best For:** B2B SaaS mobile dashboards, fintech apps, developer tool mobile companions, marketing analytics apps, HR/operations apps, modern business productivity
+
+**Key Effects:** Spring animations (mass:1 damping:15 stiffness:120); gradient buttons (0052FF→4D7CFF); scale press 0.96→1.0 with haptics; floating FAB with gentle bobbing (Reanimated); glassmorphism BlurView navigation bars; staggered fade-in entrance (Y:20→0 + opacity:0→1); pulsing status dot on section badges; layout transitions (LayoutAnimation or Reanimated entering)
+
+### Page Pattern
+
+**Pattern Name:** Enterprise Gateway
+
+- **Conversion Strategy:** Path selection (I am a...). Mega menu navigation. Trust signals prominent.
+- **CTA Placement:** Contact Sales (Primary) + Login (Secondary)
+- **Section Order:** 1. Hero (Video/Mission), 2. Solutions by Industry, 3. Solutions by Role, 4. Client Logos, 5. Contact Sales
+
+---
+
+## Anti-Patterns (Do NOT Use)
+
+- ❌ Excessive animation
+- ❌ Dark mode by default
+
+### Additional Forbidden Patterns
+
+- ❌ **Emojis as icons** — Use SVG icons (Heroicons, Lucide, Simple Icons)
+- ❌ **Missing cursor:pointer** — All clickable elements must have cursor:pointer
+- ❌ **Layout-shifting hovers** — Avoid scale transforms that shift layout
+- ❌ **Low contrast text** — Maintain 4.5:1 minimum contrast ratio
+- ❌ **Instant state changes** — Always use transitions (150-300ms)
+- ❌ **Invisible focus states** — Focus states must be visible for a11y
+
+---
+
+## Pre-Delivery Checklist
+
+Before delivering any UI code, verify:
+
+- [ ] No emojis used as icons (use SVG instead)
+- [ ] All icons from consistent icon set (Heroicons/Lucide)
+- [ ] `cursor-pointer` on all clickable elements
+- [ ] Hover states with smooth transitions (150-300ms)
+- [ ] Light mode: text contrast 4.5:1 minimum
+- [ ] Focus states visible for keyboard navigation
+- [ ] `prefers-reduced-motion` respected
+- [ ] Responsive: 375px, 768px, 1024px, 1440px
+- [ ] No content hidden behind fixed navbars
+- [ ] No horizontal scroll on mobile

--- a/package-lock.json
+++ b/package-lock.json
@@ -2123,9 +2123,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {
@@ -2377,9 +2377,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

- Adds a reusable `polish-ui` Cursor skill that gates UI polish work on `docs/design/design-system.md`.
- Expands the repository design system documentation.
- Updates dev dependency lockfile metadata for postcss and vite patch releases.

## Related issue

None

## Changes made

- Add `.cursor/skills/polish-ui/SKILL.md` with workflow, scope, and failure handling.
- Extend `docs/design/design-system.md`.
- Bump resolved versions in `package-lock.json` (postcss, vite).

## Verification

- Not run

## Notes / risks

- None
